### PR TITLE
Add B10 support

### DIFF
--- a/Leapmotor_to_HomeAssistant_B10.macro
+++ b/Leapmotor_to_HomeAssistant_B10.macro
@@ -683,6 +683,122 @@
         "m_isOrCondition": false
       },
       {
+        "childrenCollapsed": false,
+        "dontLogIfConditionIsFalse": false,
+        "disableLogging": false,
+        "m_SIGUID": -14061,
+        "m_classType": "IfConditionAction",
+        "m_constraintList": [
+          {
+            "checkCase": false,
+            "dictionaryKeys": {
+              "keys": []
+            },
+            "dictionaryType": 0,
+            "enableRegex": false,
+            "m_booleanValue": false,
+            "m_doubleValue": 0.0,
+            "m_intCompareVariable": false,
+            "m_intGreaterThan": false,
+            "m_intLessThan": false,
+            "m_intNotEqual": false,
+            "m_intValue": 0,
+            "m_stringComparisonType": 1,
+            "m_stringEqual": true,
+            "m_stringValue": "Driving",
+            "m_variable": {
+              "dictionary": {
+                "entries": [],
+                "isArray": false,
+                "variableType": 4,
+                "type": "Dictionary"
+              },
+              "isActionBlockWorkingVar": false,
+              "isLocalVar": true,
+              "isSecure": false,
+              "m_booleanValue": false,
+              "m_decimalValue": 0.0,
+              "m_intValue": 0,
+              "m_name": "tvCarState",
+              "m_stringValue": "",
+              "m_type": 2,
+              "supportsInput": false,
+              "supportsOutput": true
+            },
+            "disableLogging": false,
+            "m_SIGUID": -14062,
+            "m_classType": "MacroDroidVariableConstraint",
+            "m_constraintList": [],
+            "m_isDisabled": false,
+            "m_isOrCondition": false
+          }
+        ],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "booleanDictionaryKeys": {
+          "keys": []
+        },
+        "dictionaryKeys": [],
+        "dictionaryOrArrayType": -1,
+        "existingManualKeyType": 0,
+        "m_booleanInvert": false,
+        "m_darkMode": -1,
+        "m_doubleRandomMax": 0.0,
+        "m_doubleRandomMin": 0.0,
+        "m_falseLabel": "False",
+        "m_intExpression": false,
+        "m_intRandom": false,
+        "m_intRandomMax": 0,
+        "m_intRandomMin": 0,
+        "m_intValueDecrement": false,
+        "m_intValueIncrement": false,
+        "m_newBooleanValue": false,
+        "m_newDoubleValue": 0.0,
+        "m_newIntValue": 0,
+        "m_newStringValue": "Driving",
+        "m_trueLabel": "True",
+        "m_userPrompt": false,
+        "m_userPromptEmptyAtStart": false,
+        "m_userPromptPassword": false,
+        "m_userPromptShowCancel": true,
+        "m_userPromptStopAfterCancel": true,
+        "m_variable": {
+          "dictionary": {
+            "entries": [],
+            "isArray": false,
+            "variableType": 4,
+            "type": "Dictionary"
+          },
+          "isActionBlockWorkingVar": false,
+          "isLocalVar": true,
+          "isSecure": false,
+          "m_booleanValue": false,
+          "m_decimalValue": 0.0,
+          "m_intValue": 0,
+          "m_name": "tvCarLockState",
+          "m_stringValue": "",
+          "m_type": 2,
+          "supportsInput": false,
+          "supportsOutput": true
+        },
+        "disableLogging": false,
+        "m_SIGUID": -14063,
+        "m_classType": "SetVariableAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "disableLogging": false,
+        "m_SIGUID": -14064,
+        "m_classType": "ElseAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
         "booleanDictionaryKeys": {
           "keys": []
         },
@@ -732,6 +848,14 @@
         "disableLogging": false,
         "m_SIGUID": -14015,
         "m_classType": "SetVariableAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "disableLogging": false,
+        "m_SIGUID": -14065,
+        "m_classType": "EndIfAction",
         "m_constraintList": [],
         "m_isDisabled": false,
         "m_isOrCondition": false

--- a/Leapmotor_to_HomeAssistant_B10.macro
+++ b/Leapmotor_to_HomeAssistant_B10.macro
@@ -1,0 +1,1779 @@
+{
+  "globalVariables": [],
+  "macro": {
+    "breakpoints": [],
+    "disabledTimestamp": 0,
+    "exportedActionBlocks": [],
+    "forceEvenIfNotEnabledTimestamp": 0,
+    "isActionBlock": false,
+    "isExtra": false,
+    "isFavourite": false,
+    "lastEditedTimestamp": 1775880000900,
+    "localVariables": [
+      {
+        "dictionary": {
+          "entries": [],
+          "isArray": false,
+          "variableType": 4,
+          "type": "Dictionary"
+        },
+        "isActionBlockWorkingVar": true,
+        "isLocalVar": true,
+        "isSecure": false,
+        "m_booleanValue": false,
+        "m_decimalValue": 0.0,
+        "m_intValue": 0,
+        "m_name": "current_app",
+        "m_stringValue": "",
+        "m_type": 2,
+        "supportsInput": false,
+        "supportsOutput": true
+      },
+      {
+        "dictionary": {
+          "entries": [],
+          "isArray": false,
+          "variableType": 4,
+          "type": "Dictionary"
+        },
+        "isActionBlockWorkingVar": true,
+        "isLocalVar": true,
+        "isSecure": true,
+        "m_booleanValue": false,
+        "m_decimalValue": 0.0,
+        "m_intValue": 0,
+        "m_name": "ha_token",
+        "m_stringValue": "",
+        "m_type": 2,
+        "supportsInput": false,
+        "supportsOutput": true
+      },
+      {
+        "dictionary": {
+          "entries": [],
+          "isArray": false,
+          "variableType": 4,
+          "type": "Dictionary"
+        },
+        "isActionBlockWorkingVar": false,
+        "isLocalVar": true,
+        "isSecure": false,
+        "m_booleanValue": false,
+        "m_decimalValue": 0.0,
+        "m_intValue": 0,
+        "m_name": "ha_http_response",
+        "m_stringValue": "",
+        "m_type": 2,
+        "supportsInput": false,
+        "supportsOutput": true
+      },
+      {
+        "dictionary": {
+          "entries": [],
+          "isArray": false,
+          "variableType": 4,
+          "type": "Dictionary"
+        },
+        "isActionBlockWorkingVar": true,
+        "isLocalVar": true,
+        "isSecure": true,
+        "m_booleanValue": false,
+        "m_decimalValue": 0.0,
+        "m_intValue": 0,
+        "m_name": "ha_url",
+        "m_stringValue": "",
+        "m_type": 2,
+        "supportsInput": false,
+        "supportsOutput": true
+      },
+      {
+        "dictionary": {
+          "entries": [],
+          "isArray": false,
+          "variableType": 4,
+          "type": "Dictionary"
+        },
+        "isActionBlockWorkingVar": true,
+        "isLocalVar": true,
+        "isSecure": false,
+        "m_booleanValue": false,
+        "m_decimalValue": 0.0,
+        "m_intValue": 0,
+        "m_name": "ha_request_body",
+        "m_stringValue": "",
+        "m_type": 2,
+        "supportsInput": false,
+        "supportsOutput": true
+      },
+      {
+        "dictionary": {
+          "entries": [],
+          "isArray": false,
+          "variableType": 4,
+          "type": "Dictionary"
+        },
+        "isActionBlockWorkingVar": false,
+        "isLocalVar": true,
+        "isSecure": false,
+        "m_booleanValue": false,
+        "m_decimalValue": 0.0,
+        "m_intValue": 0,
+        "m_name": "ha_sensor_name",
+        "m_stringValue": "leapmotor_b10_1",
+        "m_type": 2,
+        "supportsInput": false,
+        "supportsOutput": true
+      },
+      {
+        "dictionary": {
+          "entries": [],
+          "isArray": false,
+          "variableType": 4,
+          "type": "Dictionary"
+        },
+        "isActionBlockWorkingVar": false,
+        "isLocalVar": true,
+        "isSecure": false,
+        "m_booleanValue": false,
+        "m_decimalValue": 0.0,
+        "m_intValue": 0,
+        "m_name": "screen_contents",
+        "m_stringValue": "",
+        "m_type": 4,
+        "supportsInput": true,
+        "supportsOutput": true
+      },
+      {
+        "dictionary": {
+          "entries": [],
+          "isArray": false,
+          "variableType": 4,
+          "type": "Dictionary"
+        },
+        "isActionBlockWorkingVar": false,
+        "isLocalVar": true,
+        "isSecure": false,
+        "m_booleanValue": false,
+        "m_decimalValue": 0.0,
+        "m_intValue": 0,
+        "m_name": "tv_soc",
+        "m_stringValue": "",
+        "m_type": 2,
+        "supportsInput": false,
+        "supportsOutput": true
+      },
+      {
+        "dictionary": {
+          "entries": [],
+          "isArray": false,
+          "variableType": 4,
+          "type": "Dictionary"
+        },
+        "isActionBlockWorkingVar": false,
+        "isLocalVar": true,
+        "isSecure": false,
+        "m_booleanValue": false,
+        "m_decimalValue": 0.0,
+        "m_intValue": 0,
+        "m_name": "tvCarLockState",
+        "m_stringValue": "",
+        "m_type": 2,
+        "supportsInput": false,
+        "supportsOutput": true
+      },
+      {
+        "dictionary": {
+          "entries": [],
+          "isArray": false,
+          "variableType": 4,
+          "type": "Dictionary"
+        },
+        "isActionBlockWorkingVar": false,
+        "isLocalVar": true,
+        "isSecure": false,
+        "m_booleanValue": false,
+        "m_decimalValue": 0.0,
+        "m_intValue": 0,
+        "m_name": "tvCarState",
+        "m_stringValue": "",
+        "m_type": 2,
+        "supportsInput": false,
+        "supportsOutput": true
+      },
+      {
+        "dictionary": {
+          "entries": [],
+          "isArray": false,
+          "variableType": 4,
+          "type": "Dictionary"
+        },
+        "isActionBlockWorkingVar": false,
+        "isLocalVar": true,
+        "isSecure": false,
+        "m_booleanValue": false,
+        "m_decimalValue": 0.0,
+        "m_intValue": 0,
+        "m_name": "tvHomeAirTemp1",
+        "m_stringValue": "",
+        "m_type": 2,
+        "supportsInput": false,
+        "supportsOutput": true
+      },
+      {
+        "dictionary": {
+          "entries": [],
+          "isArray": false,
+          "variableType": 4,
+          "type": "Dictionary"
+        },
+        "isActionBlockWorkingVar": false,
+        "isLocalVar": true,
+        "isSecure": false,
+        "m_booleanValue": false,
+        "m_decimalValue": 0.0,
+        "m_intValue": 0,
+        "m_name": "tvHomeCarTemp1",
+        "m_stringValue": "",
+        "m_type": 2,
+        "supportsInput": false,
+        "supportsOutput": true
+      },
+      {
+        "dictionary": {
+          "entries": [],
+          "isArray": false,
+          "variableType": 4,
+          "type": "Dictionary"
+        },
+        "isActionBlockWorkingVar": false,
+        "isLocalVar": true,
+        "isSecure": false,
+        "m_booleanValue": false,
+        "m_decimalValue": 0.0,
+        "m_intValue": 0,
+        "m_name": "tvRemainMileage",
+        "m_stringValue": "",
+        "m_type": 2,
+        "supportsInput": false,
+        "supportsOutput": true
+      },
+      {
+        "dictionary": {
+          "entries": [],
+          "isArray": false,
+          "variableType": 4,
+          "type": "Dictionary"
+        },
+        "isActionBlockWorkingVar": false,
+        "isLocalVar": true,
+        "isSecure": false,
+        "m_booleanValue": false,
+        "m_decimalValue": 0.0,
+        "m_intValue": 0,
+        "m_name": "tvOdometer",
+        "m_stringValue": "0",
+        "m_type": 2,
+        "supportsInput": false,
+        "supportsOutput": true
+      },
+      {
+        "dictionary": {
+          "entries": [],
+          "isArray": false,
+          "variableType": 4,
+          "type": "Dictionary"
+        },
+        "isActionBlockWorkingVar": false,
+        "isLocalVar": true,
+        "isSecure": false,
+        "m_booleanValue": false,
+        "m_decimalValue": 0.0,
+        "m_intValue": 0,
+        "m_name": "tv_charge_current",
+        "m_stringValue": "",
+        "m_type": 2,
+        "supportsInput": false,
+        "supportsOutput": true
+      },
+      {
+        "dictionary": {
+          "entries": [],
+          "isArray": false,
+          "variableType": 4,
+          "type": "Dictionary"
+        },
+        "isActionBlockWorkingVar": false,
+        "isLocalVar": true,
+        "isSecure": false,
+        "m_booleanValue": false,
+        "m_decimalValue": 0.0,
+        "m_intValue": 0,
+        "m_name": "tv_charge_power",
+        "m_stringValue": "0",
+        "m_type": 2,
+        "supportsInput": false,
+        "supportsOutput": true
+      },
+      {
+        "dictionary": {
+          "entries": [],
+          "isArray": false,
+          "variableType": 4,
+          "type": "Dictionary"
+        },
+        "isActionBlockWorkingVar": false,
+        "isLocalVar": true,
+        "isSecure": false,
+        "m_booleanValue": false,
+        "m_decimalValue": 0.0,
+        "m_intValue": 0,
+        "m_name": "tv_charge_limit",
+        "m_stringValue": "",
+        "m_type": 2,
+        "supportsInput": false,
+        "supportsOutput": true
+      },
+      {
+        "dictionary": {
+          "entries": [],
+          "isArray": false,
+          "variableType": 4,
+          "type": "Dictionary"
+        },
+        "isActionBlockWorkingVar": false,
+        "isLocalVar": true,
+        "isSecure": false,
+        "m_booleanValue": false,
+        "m_decimalValue": 0.0,
+        "m_intValue": 0,
+        "m_name": "tv_charge_remaining",
+        "m_stringValue": "",
+        "m_type": 2,
+        "supportsInput": false,
+        "supportsOutput": true
+      },
+      {
+        "dictionary": {
+          "entries": [],
+          "isArray": false,
+          "variableType": 4,
+          "type": "Dictionary"
+        },
+        "isActionBlockWorkingVar": false,
+        "isLocalVar": true,
+        "isSecure": false,
+        "m_booleanValue": false,
+        "m_decimalValue": 0.0,
+        "m_intValue": 0,
+        "m_name": "charge_status",
+        "m_stringValue": "A",
+        "m_type": 2,
+        "supportsInput": false,
+        "supportsOutput": true
+      }
+    ],
+    "m_actionList": [
+      {
+        "booleanDictionaryKeys": {
+          "keys": []
+        },
+        "dictionaryKeys": [],
+        "dictionaryOrArrayType": -1,
+        "existingManualKeyType": 0,
+        "m_booleanInvert": false,
+        "m_darkMode": -1,
+        "m_doubleRandomMax": 0.0,
+        "m_doubleRandomMin": 0.0,
+        "m_falseLabel": "False",
+        "m_intExpression": false,
+        "m_intRandom": false,
+        "m_intRandomMax": 0,
+        "m_intRandomMin": 0,
+        "m_intValueDecrement": false,
+        "m_intValueIncrement": false,
+        "m_newBooleanValue": false,
+        "m_newDoubleValue": 0.0,
+        "m_newIntValue": 0,
+        "m_newStringValue": "{fg_app_package}",
+        "m_trueLabel": "True",
+        "m_userPrompt": false,
+        "m_userPromptEmptyAtStart": false,
+        "m_userPromptPassword": false,
+        "m_userPromptShowCancel": true,
+        "m_userPromptStopAfterCancel": true,
+        "m_variable": {
+          "dictionary": {
+            "entries": [],
+            "isArray": false,
+            "variableType": 4,
+            "type": "Dictionary"
+          },
+          "isActionBlockWorkingVar": true,
+          "isLocalVar": true,
+          "isSecure": false,
+          "m_booleanValue": false,
+          "m_decimalValue": 0.0,
+          "m_intValue": 0,
+          "m_name": "current_app",
+          "m_stringValue": "",
+          "m_type": 2,
+          "supportsInput": false,
+          "supportsOutput": true
+        },
+        "disableLogging": false,
+        "m_SIGUID": -14001,
+        "m_classType": "SetVariableAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "m_applicationName": "Leapmotor",
+        "m_excludeFromRecents": true,
+        "m_packageToLaunch": "com.leapmotorinternational.global",
+        "m_startNew": true,
+        "option": 0,
+        "disableLogging": false,
+        "m_SIGUID": -14002,
+        "m_classType": "LaunchActivityAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "m_delayInMilliSeconds": 0,
+        "m_delayInSeconds": 10,
+        "m_useAlarm": false,
+        "unitForVariables": 0,
+        "disableLogging": false,
+        "m_SIGUID": -14003,
+        "m_classType": "PauseAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "m_fixedOptionCount": 20,
+        "m_option": 1,
+        "childrenCollapsed": false,
+        "dontLogIfConditionIsFalse": false,
+        "disableLogging": false,
+        "m_SIGUID": -14003,
+        "m_classType": "LoopAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "dictionaryKeys": {
+          "keys": []
+        },
+        "forceScreenRefresh": false,
+        "includeOverlays": false,
+        "includeScreenLocation": true,
+        "includeWithoutText": false,
+        "isLocalVar": true,
+        "variableName": "screen_contents",
+        "disableLogging": false,
+        "m_SIGUID": -14004,
+        "m_classType": "ReadScreenContentsAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "childrenCollapsed": false,
+        "dontLogIfConditionIsFalse": false,
+        "disableLogging": false,
+        "m_SIGUID": -14005,
+        "m_classType": "IfConditionAction",
+        "m_constraintList": [
+          {
+            "checkCase": false,
+            "dictionaryKeys": {
+              "keys": [
+                "com.leapmotorinternational.global:id/btLpHomeData",
+                "text"
+              ]
+            },
+            "dictionaryType": 2,
+            "enableRegex": true,
+            "m_booleanValue": false,
+            "m_doubleValue": 0.0,
+            "m_intCompareVariable": false,
+            "m_intGreaterThan": false,
+            "m_intLessThan": false,
+            "m_intNotEqual": false,
+            "m_intValue": 0,
+            "m_stringComparisonType": 1,
+            "m_stringEqual": true,
+            "m_stringValue": "energy",
+            "m_variable": {
+              "dictionary": {
+                "entries": [],
+                "isArray": false,
+                "variableType": 4,
+                "type": "Dictionary"
+              },
+              "isActionBlockWorkingVar": false,
+              "isLocalVar": true,
+              "isSecure": false,
+              "m_booleanValue": false,
+              "m_decimalValue": 0.0,
+              "m_intValue": 0,
+              "m_name": "screen_contents",
+              "m_stringValue": "",
+              "m_type": 4,
+              "supportsInput": true,
+              "supportsOutput": true
+            },
+            "disableLogging": false,
+            "m_SIGUID": -14006,
+            "m_classType": "MacroDroidVariableConstraint",
+            "m_constraintList": [],
+            "m_isDisabled": false,
+            "m_isOrCondition": false
+          }
+        ],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "disableLogging": false,
+        "m_SIGUID": -14007,
+        "m_classType": "BreakFromLoopAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "disableLogging": false,
+        "m_SIGUID": -14008,
+        "m_classType": "EndIfAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "m_delayInMilliSeconds": 250,
+        "m_delayInSeconds": 0,
+        "m_useAlarm": false,
+        "unitForVariables": 0,
+        "disableLogging": false,
+        "m_SIGUID": -14009,
+        "m_classType": "PauseAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "disableLogging": false,
+        "m_SIGUID": -14010,
+        "m_classType": "EndLoopAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "m_option": 2,
+        "m_text": "{lv=screen_contents[com.leapmotorinternational.global:id/tvHomeAirTemp1][text]}",
+        "m_textManipulation": {
+          "type": "ExtractTextManipulation",
+          "params": [
+            "\\d+\\.?\\d*",
+            "0"
+          ]
+        },
+        "variableName": "tvHomeAirTemp1",
+        "disableLogging": false,
+        "m_SIGUID": -14011,
+        "m_classType": "TextManipulationAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "m_option": 2,
+        "m_text": "{lv=screen_contents[com.leapmotorinternational.global:id/tvHomeCarTemp1][text]}",
+        "m_textManipulation": {
+          "type": "ExtractTextManipulation",
+          "params": [
+            "\\d+\\.?\\d*",
+            "0"
+          ]
+        },
+        "variableName": "tvHomeCarTemp1",
+        "disableLogging": false,
+        "m_SIGUID": -14012,
+        "m_classType": "TextManipulationAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "m_option": 2,
+        "m_text": "{lv=screen_contents[com.leapmotorinternational.global:id/tvRemainMileage][text]}",
+        "m_textManipulation": {
+          "type": "ExtractTextManipulation",
+          "params": [
+            "\\d+\\.?\\d*",
+            "0"
+          ]
+        },
+        "variableName": "tvRemainMileage",
+        "disableLogging": false,
+        "m_SIGUID": -14013,
+        "m_classType": "TextManipulationAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "booleanDictionaryKeys": {
+          "keys": []
+        },
+        "dictionaryKeys": [],
+        "dictionaryOrArrayType": -1,
+        "existingManualKeyType": 0,
+        "m_booleanInvert": false,
+        "m_darkMode": -1,
+        "m_doubleRandomMax": 0.0,
+        "m_doubleRandomMin": 0.0,
+        "m_falseLabel": "False",
+        "m_intExpression": false,
+        "m_intRandom": false,
+        "m_intRandomMax": 0,
+        "m_intRandomMin": 0,
+        "m_intValueDecrement": false,
+        "m_intValueIncrement": false,
+        "m_newBooleanValue": false,
+        "m_newDoubleValue": 0.0,
+        "m_newIntValue": 0,
+        "m_newStringValue": "{lv=screen_contents[com.leapmotorinternational.global:id/tvCarState][text]}",
+        "m_trueLabel": "True",
+        "m_userPrompt": false,
+        "m_userPromptEmptyAtStart": false,
+        "m_userPromptPassword": false,
+        "m_userPromptShowCancel": true,
+        "m_userPromptStopAfterCancel": true,
+        "m_variable": {
+          "dictionary": {
+            "entries": [],
+            "isArray": false,
+            "variableType": 4,
+            "type": "Dictionary"
+          },
+          "isActionBlockWorkingVar": true,
+          "isLocalVar": true,
+          "isSecure": false,
+          "m_booleanValue": false,
+          "m_decimalValue": 0.0,
+          "m_intValue": 0,
+          "m_name": "tvCarState",
+          "m_stringValue": "",
+          "m_type": 2,
+          "supportsInput": false,
+          "supportsOutput": true
+        },
+        "disableLogging": false,
+        "m_SIGUID": -14014,
+        "m_classType": "SetVariableAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "booleanDictionaryKeys": {
+          "keys": []
+        },
+        "dictionaryKeys": [],
+        "dictionaryOrArrayType": -1,
+        "existingManualKeyType": 0,
+        "m_booleanInvert": false,
+        "m_darkMode": -1,
+        "m_doubleRandomMax": 0.0,
+        "m_doubleRandomMin": 0.0,
+        "m_falseLabel": "False",
+        "m_intExpression": false,
+        "m_intRandom": false,
+        "m_intRandomMax": 0,
+        "m_intRandomMin": 0,
+        "m_intValueDecrement": false,
+        "m_intValueIncrement": false,
+        "m_newBooleanValue": false,
+        "m_newDoubleValue": 0.0,
+        "m_newIntValue": 0,
+        "m_newStringValue": "{lv=screen_contents[com.leapmotorinternational.global:id/tvLockCarState][text]}",
+        "m_trueLabel": "True",
+        "m_userPrompt": false,
+        "m_userPromptEmptyAtStart": false,
+        "m_userPromptPassword": false,
+        "m_userPromptShowCancel": true,
+        "m_userPromptStopAfterCancel": true,
+        "m_variable": {
+          "dictionary": {
+            "entries": [],
+            "isArray": false,
+            "variableType": 4,
+            "type": "Dictionary"
+          },
+          "isActionBlockWorkingVar": false,
+          "isLocalVar": true,
+          "isSecure": false,
+          "m_booleanValue": false,
+          "m_decimalValue": 0.0,
+          "m_intValue": 0,
+          "m_name": "tvCarLockState",
+          "m_stringValue": "",
+          "m_type": 2,
+          "supportsInput": false,
+          "supportsOutput": true
+        },
+        "disableLogging": false,
+        "m_SIGUID": -14015,
+        "m_classType": "SetVariableAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "action": 0,
+        "uiInteractionConfiguration": {
+          "blocking": true,
+          "checkOverlays": false,
+          "clickOption": 0,
+          "contentDescription": "",
+          "longClick": false,
+          "skipCount": "0",
+          "textContent": "",
+          "textMatchOption": 0,
+          "useRegex": false,
+          "viewId": "",
+          "xyPercentages": true,
+          "xyPoint": {
+            "x": 0,
+            "y": 0
+          },
+          "startXPercent": 50,
+          "startYPercent": 75,
+          "endXPercent": 50,
+          "endYPercent": 25,
+          "duration": 500,
+          "type": "Swipe"
+        },
+        "disableLogging": false,
+        "m_SIGUID": -14016,
+        "m_classType": "UIInteractionAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "m_delayInMilliSeconds": 600,
+        "m_delayInSeconds": 0,
+        "m_useAlarm": false,
+        "unitForVariables": 0,
+        "disableLogging": false,
+        "m_SIGUID": -14017,
+        "m_classType": "PauseAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "dictionaryKeys": {
+          "keys": []
+        },
+        "forceScreenRefresh": true,
+        "includeOverlays": false,
+        "includeScreenLocation": true,
+        "includeWithoutText": false,
+        "isLocalVar": true,
+        "variableName": "screen_contents",
+        "disableLogging": false,
+        "m_SIGUID": -14018,
+        "m_classType": "ReadScreenContentsAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "m_option": 2,
+        "m_text": "{lv=screen_contents[com.leapmotorinternational.global:id/tvLphomeTripData][text]}",
+        "m_textManipulation": {
+          "type": "ExtractTextManipulation",
+          "params": [
+            "\\d+",
+            "0"
+          ]
+        },
+        "variableName": "tvOdometer",
+        "disableLogging": false,
+        "m_SIGUID": -14019,
+        "m_classType": "TextManipulationAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "action": 0,
+        "uiInteractionConfiguration": {
+          "blocking": false,
+          "checkOverlays": false,
+          "clickOption": 3,
+          "contentDescription": "",
+          "longClick": false,
+          "skipCount": "0",
+          "textContent": "",
+          "textMatchOption": 1,
+          "useRegex": false,
+          "viewId": "com.leapmotorinternational.global:id/tvRemainMileage",
+          "xyPercentages": false,
+          "xyPoint": {
+            "x": 153,
+            "y": 371
+          },
+          "type": "Click"
+        },
+        "disableLogging": false,
+        "m_SIGUID": -14020,
+        "m_classType": "UIInteractionAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "m_fixedOptionCount": 20,
+        "m_option": 1,
+        "childrenCollapsed": false,
+        "dontLogIfConditionIsFalse": false,
+        "disableLogging": false,
+        "m_SIGUID": -14021,
+        "m_classType": "LoopAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "dictionaryKeys": {
+          "keys": []
+        },
+        "forceScreenRefresh": false,
+        "includeOverlays": false,
+        "includeScreenLocation": true,
+        "includeWithoutText": false,
+        "isLocalVar": true,
+        "variableName": "screen_contents",
+        "disableLogging": false,
+        "m_SIGUID": -14022,
+        "m_classType": "ReadScreenContentsAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "childrenCollapsed": false,
+        "dontLogIfConditionIsFalse": false,
+        "disableLogging": false,
+        "m_SIGUID": -14023,
+        "m_classType": "IfConditionAction",
+        "m_constraintList": [
+          {
+            "checkCase": false,
+            "dictionaryKeys": {
+              "keys": [
+                "com.leapmotorinternational.global:id/tv_soc",
+                "text"
+              ]
+            },
+            "dictionaryType": 2,
+            "enableRegex": true,
+            "m_booleanValue": false,
+            "m_doubleValue": 0.0,
+            "m_intCompareVariable": false,
+            "m_intGreaterThan": false,
+            "m_intLessThan": false,
+            "m_intNotEqual": false,
+            "m_intValue": 0,
+            "m_stringComparisonType": 1,
+            "m_stringEqual": true,
+            "m_stringValue": "[0-9]+%",
+            "m_variable": {
+              "dictionary": {
+                "entries": [],
+                "isArray": false,
+                "variableType": 4,
+                "type": "Dictionary"
+              },
+              "isActionBlockWorkingVar": false,
+              "isLocalVar": true,
+              "isSecure": false,
+              "m_booleanValue": false,
+              "m_decimalValue": 0.0,
+              "m_intValue": 0,
+              "m_name": "screen_contents",
+              "m_stringValue": "",
+              "m_type": 4,
+              "supportsInput": true,
+              "supportsOutput": true
+            },
+            "disableLogging": false,
+            "m_SIGUID": -14024,
+            "m_classType": "MacroDroidVariableConstraint",
+            "m_constraintList": [],
+            "m_isDisabled": false,
+            "m_isOrCondition": false
+          }
+        ],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "m_option": 2,
+        "m_text": "{lv=screen_contents[com.leapmotorinternational.global:id/tv_soc][text]}",
+        "m_textManipulation": {
+          "type": "ExtractTextManipulation",
+          "params": [
+            "[0-9]+",
+            "0"
+          ]
+        },
+        "variableName": "tv_soc",
+        "disableLogging": false,
+        "m_SIGUID": -14025,
+        "m_classType": "TextManipulationAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "disableLogging": false,
+        "m_SIGUID": -14027,
+        "m_classType": "BreakFromLoopAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "disableLogging": false,
+        "m_SIGUID": -14028,
+        "m_classType": "EndIfAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "m_delayInMilliSeconds": 250,
+        "m_delayInSeconds": 0,
+        "m_useAlarm": false,
+        "unitForVariables": 0,
+        "disableLogging": false,
+        "m_SIGUID": -14029,
+        "m_classType": "PauseAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "disableLogging": false,
+        "m_SIGUID": -14030,
+        "m_classType": "EndLoopAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "dictionaryKeys": {
+          "keys": []
+        },
+        "forceScreenRefresh": true,
+        "includeOverlays": false,
+        "includeScreenLocation": true,
+        "includeWithoutText": false,
+        "isLocalVar": true,
+        "variableName": "screen_contents",
+        "disableLogging": false,
+        "m_SIGUID": -14031,
+        "m_classType": "ReadScreenContentsAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "m_option": 2,
+        "m_text": "{lv=screen_contents[com.leapmotorinternational.global:id/tv_charge_limit][text]}",
+        "m_textManipulation": {
+          "type": "ExtractTextManipulation",
+          "params": [
+            "[0-9]+(?=%)",
+            "0"
+          ]
+        },
+        "variableName": "tv_charge_limit",
+        "disableLogging": false,
+        "m_SIGUID": -14036,
+        "m_classType": "TextManipulationAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "childrenCollapsed": false,
+        "dontLogIfConditionIsFalse": false,
+        "disableLogging": false,
+        "m_SIGUID": -14032,
+        "m_classType": "IfConditionAction",
+        "m_constraintList": [
+          {
+            "checkCase": false,
+            "dictionaryKeys": {
+              "keys": [
+                "com.leapmotorinternational.global:id/tv_text",
+                "text"
+              ]
+            },
+            "dictionaryType": 2,
+            "enableRegex": true,
+            "m_booleanValue": false,
+            "m_doubleValue": 0.0,
+            "m_intCompareVariable": false,
+            "m_intGreaterThan": false,
+            "m_intLessThan": false,
+            "m_intNotEqual": false,
+            "m_intValue": 0,
+            "m_stringComparisonType": 1,
+            "m_stringEqual": true,
+            "m_stringValue": ".+",
+            "m_variable": {
+              "dictionary": {
+                "entries": [],
+                "isArray": false,
+                "variableType": 4,
+                "type": "Dictionary"
+              },
+              "isActionBlockWorkingVar": false,
+              "isLocalVar": true,
+              "isSecure": false,
+              "m_booleanValue": false,
+              "m_decimalValue": 0.0,
+              "m_intValue": 0,
+              "m_name": "screen_contents",
+              "m_stringValue": "",
+              "m_type": 4,
+              "supportsInput": true,
+              "supportsOutput": true
+            },
+            "disableLogging": false,
+            "m_SIGUID": -14033,
+            "m_classType": "MacroDroidVariableConstraint",
+            "m_constraintList": [],
+            "m_isDisabled": false,
+            "m_isOrCondition": false
+          }
+        ],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "m_option": 2,
+        "m_text": "{lv=screen_contents[com.leapmotorinternational.global:id/tv_current][text]}",
+        "m_textManipulation": {
+          "type": "ExtractTextManipulation",
+          "params": [
+            "[0-9,\\.]+",
+            "0"
+          ]
+        },
+        "variableName": "tv_charge_current",
+        "disableLogging": false,
+        "m_SIGUID": -14034,
+        "m_classType": "TextManipulationAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "m_option": 2,
+        "m_text": "{lv=screen_contents[com.leapmotorinternational.global:id/tv_power2][text]}",
+        "m_textManipulation": {
+          "type": "ExtractTextManipulation",
+          "params": [
+            "[0-9,\\.]+",
+            "0"
+          ]
+        },
+        "variableName": "tv_charge_power",
+        "disableLogging": false,
+        "m_SIGUID": -14035,
+        "m_classType": "TextManipulationAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "m_option": 2,
+        "m_text": "{lv=screen_contents[com.leapmotorinternational.global:id/tv_charge_state][text]}",
+        "m_textManipulation": {
+          "type": "NoManipulation"
+        },
+        "variableName": "tv_charge_remaining",
+        "disableLogging": false,
+        "m_SIGUID": -14026,
+        "m_classType": "TextManipulationAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "childrenCollapsed": false,
+        "dontLogIfConditionIsFalse": false,
+        "disableLogging": false,
+        "m_SIGUID": -14037,
+        "m_classType": "IfConditionAction",
+        "m_constraintList": [
+          {
+            "checkCase": false,
+            "dictionaryKeys": {
+              "keys": [
+                "com.leapmotorinternational.global:id/tv_current",
+                "text"
+              ]
+            },
+            "dictionaryType": 2,
+            "enableRegex": true,
+            "m_booleanValue": false,
+            "m_doubleValue": 0.0,
+            "m_intCompareVariable": false,
+            "m_intGreaterThan": false,
+            "m_intLessThan": false,
+            "m_intNotEqual": false,
+            "m_intValue": 0,
+            "m_stringComparisonType": 1,
+            "m_stringEqual": true,
+            "m_stringValue": ".+",
+            "m_variable": {
+              "dictionary": {
+                "entries": [],
+                "isArray": false,
+                "variableType": 4,
+                "type": "Dictionary"
+              },
+              "isActionBlockWorkingVar": false,
+              "isLocalVar": true,
+              "isSecure": false,
+              "m_booleanValue": false,
+              "m_decimalValue": 0.0,
+              "m_intValue": 0,
+              "m_name": "screen_contents",
+              "m_stringValue": "",
+              "m_type": 4,
+              "supportsInput": true,
+              "supportsOutput": true
+            },
+            "disableLogging": false,
+            "m_SIGUID": -14038,
+            "m_classType": "MacroDroidVariableConstraint",
+            "m_constraintList": [],
+            "m_isDisabled": false,
+            "m_isOrCondition": false
+          }
+        ],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "booleanDictionaryKeys": {
+          "keys": []
+        },
+        "dictionaryKeys": [],
+        "dictionaryOrArrayType": -1,
+        "existingManualKeyType": 0,
+        "m_booleanInvert": false,
+        "m_darkMode": -1,
+        "m_doubleRandomMax": 0.0,
+        "m_doubleRandomMin": 0.0,
+        "m_falseLabel": "False",
+        "m_intExpression": false,
+        "m_intRandom": false,
+        "m_intRandomMax": 0,
+        "m_intRandomMin": 0,
+        "m_intValueDecrement": false,
+        "m_intValueIncrement": false,
+        "m_newBooleanValue": false,
+        "m_newDoubleValue": 0.0,
+        "m_newIntValue": 0,
+        "m_newStringValue": "C",
+        "m_trueLabel": "True",
+        "m_userPrompt": false,
+        "m_userPromptEmptyAtStart": false,
+        "m_userPromptPassword": false,
+        "m_userPromptShowCancel": true,
+        "m_userPromptStopAfterCancel": true,
+        "m_variable": {
+          "dictionary": {
+            "entries": [],
+            "isArray": false,
+            "variableType": 4,
+            "type": "Dictionary"
+          },
+          "isActionBlockWorkingVar": false,
+          "isLocalVar": true,
+          "isSecure": false,
+          "m_booleanValue": false,
+          "m_decimalValue": 0.0,
+          "m_intValue": 0,
+          "m_name": "charge_status",
+          "m_stringValue": "",
+          "m_type": 2,
+          "supportsInput": false,
+          "supportsOutput": true
+        },
+        "disableLogging": false,
+        "m_SIGUID": -14039,
+        "m_classType": "SetVariableAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "booleanDictionaryKeys": {
+          "keys": []
+        },
+        "dictionaryKeys": [],
+        "dictionaryOrArrayType": -1,
+        "existingManualKeyType": 0,
+        "m_booleanInvert": false,
+        "m_darkMode": -1,
+        "m_doubleRandomMax": 0.0,
+        "m_doubleRandomMin": 0.0,
+        "m_falseLabel": "False",
+        "m_intExpression": false,
+        "m_intRandom": false,
+        "m_intRandomMax": 0,
+        "m_intRandomMin": 0,
+        "m_intValueDecrement": false,
+        "m_intValueIncrement": false,
+        "m_newBooleanValue": false,
+        "m_newDoubleValue": 0.0,
+        "m_newIntValue": 0,
+        "m_newStringValue": "{\n  \"state\": \"Charging\",\n  \"attributes\": {\n    \"battery_percent\": {lv=tv_soc},\n    \"charge_current_a\": \"{lv=tv_charge_current}\",\n    \"charge_power_kw\": \"{lv=tv_charge_power}\",\n    \"charge_limit_percent\": {lv=tv_charge_limit},\n    \"charge_remaining\": \"{lv=tv_charge_remaining}\",\n    \"air_temp\": {lv=tvHomeAirTemp1},\n    \"car_temp\": {lv=tvHomeCarTemp1},\n    \"lock_state\": \"{lv=tvCarLockState}\",\n    \"remaining_range\": {lv=tvRemainMileage},\n    \"odometer\": \"{lv=tvOdometer}\",\n    \"friendly_name\": \"Leapmotor B10\",\n    \"icon\": \"mdi:car-electric\"\n  },\n  \"force_update\": true\n}",
+        "m_trueLabel": "True",
+        "m_userPrompt": false,
+        "m_userPromptEmptyAtStart": false,
+        "m_userPromptPassword": false,
+        "m_userPromptShowCancel": true,
+        "m_userPromptStopAfterCancel": true,
+        "m_variable": {
+          "dictionary": {
+            "entries": [],
+            "isArray": false,
+            "variableType": 4,
+            "type": "Dictionary"
+          },
+          "isActionBlockWorkingVar": true,
+          "isLocalVar": true,
+          "isSecure": false,
+          "m_booleanValue": false,
+          "m_decimalValue": 0.0,
+          "m_intValue": 0,
+          "m_name": "ha_request_body",
+          "m_stringValue": "",
+          "m_type": 2,
+          "supportsInput": false,
+          "supportsOutput": true
+        },
+        "disableLogging": false,
+        "m_SIGUID": -14040,
+        "m_classType": "SetVariableAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "disableLogging": false,
+        "m_SIGUID": -14041,
+        "m_classType": "ElseAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "booleanDictionaryKeys": {
+          "keys": []
+        },
+        "dictionaryKeys": [],
+        "dictionaryOrArrayType": -1,
+        "existingManualKeyType": 0,
+        "m_booleanInvert": false,
+        "m_darkMode": -1,
+        "m_doubleRandomMax": 0.0,
+        "m_doubleRandomMin": 0.0,
+        "m_falseLabel": "False",
+        "m_intExpression": false,
+        "m_intRandom": false,
+        "m_intRandomMax": 0,
+        "m_intRandomMin": 0,
+        "m_intValueDecrement": false,
+        "m_intValueIncrement": false,
+        "m_newBooleanValue": false,
+        "m_newDoubleValue": 0.0,
+        "m_newIntValue": 0,
+        "m_newStringValue": "B",
+        "m_trueLabel": "True",
+        "m_userPrompt": false,
+        "m_userPromptEmptyAtStart": false,
+        "m_userPromptPassword": false,
+        "m_userPromptShowCancel": true,
+        "m_userPromptStopAfterCancel": true,
+        "m_variable": {
+          "dictionary": {
+            "entries": [],
+            "isArray": false,
+            "variableType": 4,
+            "type": "Dictionary"
+          },
+          "isActionBlockWorkingVar": false,
+          "isLocalVar": true,
+          "isSecure": false,
+          "m_booleanValue": false,
+          "m_decimalValue": 0.0,
+          "m_intValue": 0,
+          "m_name": "charge_status",
+          "m_stringValue": "",
+          "m_type": 2,
+          "supportsInput": false,
+          "supportsOutput": true
+        },
+        "disableLogging": false,
+        "m_SIGUID": -14042,
+        "m_classType": "SetVariableAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "booleanDictionaryKeys": {
+          "keys": []
+        },
+        "dictionaryKeys": [],
+        "dictionaryOrArrayType": -1,
+        "existingManualKeyType": 0,
+        "m_booleanInvert": false,
+        "m_darkMode": -1,
+        "m_doubleRandomMax": 0.0,
+        "m_doubleRandomMin": 0.0,
+        "m_falseLabel": "False",
+        "m_intExpression": false,
+        "m_intRandom": false,
+        "m_intRandomMax": 0,
+        "m_intRandomMin": 0,
+        "m_intValueDecrement": false,
+        "m_intValueIncrement": false,
+        "m_newBooleanValue": false,
+        "m_newDoubleValue": 0.0,
+        "m_newIntValue": 0,
+        "m_newStringValue": "{\n  \"state\": \"{lv=tvCarState}\",\n  \"attributes\": {\n    \"battery_percent\": {lv=tv_soc},\n    \"air_temp\": {lv=tvHomeAirTemp1},\n    \"car_temp\": {lv=tvHomeCarTemp1},\n    \"lock_state\": \"{lv=tvCarLockState}\",\n    \"remaining_range\": {lv=tvRemainMileage},\n    \"odometer\": \"{lv=tvOdometer}\",\n    \"charge_current_a\": \"0\",\n    \"charge_power_kw\": \"0\",\n    \"charge_limit_percent\": {lv=tv_charge_limit},\n    \"charge_remaining\": 0,\n    \"friendly_name\": \"Leapmotor B10\",\n    \"icon\": \"mdi:car-electric\"\n  },\n  \"force_update\": true\n}",
+        "m_trueLabel": "True",
+        "m_userPrompt": false,
+        "m_userPromptEmptyAtStart": false,
+        "m_userPromptPassword": false,
+        "m_userPromptShowCancel": true,
+        "m_userPromptStopAfterCancel": true,
+        "m_variable": {
+          "dictionary": {
+            "entries": [],
+            "isArray": false,
+            "variableType": 4,
+            "type": "Dictionary"
+          },
+          "isActionBlockWorkingVar": true,
+          "isLocalVar": true,
+          "isSecure": false,
+          "m_booleanValue": false,
+          "m_decimalValue": 0.0,
+          "m_intValue": 0,
+          "m_name": "ha_request_body",
+          "m_stringValue": "",
+          "m_type": 2,
+          "supportsInput": false,
+          "supportsOutput": true
+        },
+        "disableLogging": false,
+        "m_SIGUID": -14043,
+        "m_classType": "SetVariableAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "disableLogging": false,
+        "m_SIGUID": -14044,
+        "m_classType": "EndIfAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "disableLogging": false,
+        "m_SIGUID": -14045,
+        "m_classType": "ElseAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "booleanDictionaryKeys": {
+          "keys": []
+        },
+        "dictionaryKeys": [],
+        "dictionaryOrArrayType": -1,
+        "existingManualKeyType": 0,
+        "m_booleanInvert": false,
+        "m_darkMode": -1,
+        "m_doubleRandomMax": 0.0,
+        "m_doubleRandomMin": 0.0,
+        "m_falseLabel": "False",
+        "m_intExpression": false,
+        "m_intRandom": false,
+        "m_intRandomMax": 0,
+        "m_intRandomMin": 0,
+        "m_intValueDecrement": false,
+        "m_intValueIncrement": false,
+        "m_newBooleanValue": false,
+        "m_newDoubleValue": 0.0,
+        "m_newIntValue": 0,
+        "m_newStringValue": "A",
+        "m_trueLabel": "True",
+        "m_userPrompt": false,
+        "m_userPromptEmptyAtStart": false,
+        "m_userPromptPassword": false,
+        "m_userPromptShowCancel": true,
+        "m_userPromptStopAfterCancel": true,
+        "m_variable": {
+          "dictionary": {
+            "entries": [],
+            "isArray": false,
+            "variableType": 4,
+            "type": "Dictionary"
+          },
+          "isActionBlockWorkingVar": false,
+          "isLocalVar": true,
+          "isSecure": false,
+          "m_booleanValue": false,
+          "m_decimalValue": 0.0,
+          "m_intValue": 0,
+          "m_name": "charge_status",
+          "m_stringValue": "",
+          "m_type": 2,
+          "supportsInput": false,
+          "supportsOutput": true
+        },
+        "disableLogging": false,
+        "m_SIGUID": -14046,
+        "m_classType": "SetVariableAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "booleanDictionaryKeys": {
+          "keys": []
+        },
+        "dictionaryKeys": [],
+        "dictionaryOrArrayType": -1,
+        "existingManualKeyType": 0,
+        "m_booleanInvert": false,
+        "m_darkMode": -1,
+        "m_doubleRandomMax": 0.0,
+        "m_doubleRandomMin": 0.0,
+        "m_falseLabel": "False",
+        "m_intExpression": false,
+        "m_intRandom": false,
+        "m_intRandomMax": 0,
+        "m_intRandomMin": 0,
+        "m_intValueDecrement": false,
+        "m_intValueIncrement": false,
+        "m_newBooleanValue": false,
+        "m_newDoubleValue": 0.0,
+        "m_newIntValue": 0,
+        "m_newStringValue": "{\n  \"state\": \"{lv=tvCarState}\",\n  \"attributes\": {\n    \"battery_percent\": {lv=tv_soc},\n    \"air_temp\": {lv=tvHomeAirTemp1},\n    \"car_temp\": {lv=tvHomeCarTemp1},\n    \"lock_state\": \"{lv=tvCarLockState}\",\n    \"remaining_range\": {lv=tvRemainMileage},\n    \"odometer\": \"{lv=tvOdometer}\",\n    \"charge_current_a\": \"0\",\n    \"charge_power_kw\": \"0\",\n    \"charge_limit_percent\": {lv=tv_charge_limit},\n    \"charge_remaining\": 0,\n    \"friendly_name\": \"Leapmotor B10\",\n    \"icon\": \"mdi:car-electric\"\n  },\n  \"force_update\": true\n}",
+        "m_trueLabel": "True",
+        "m_userPrompt": false,
+        "m_userPromptEmptyAtStart": false,
+        "m_userPromptPassword": false,
+        "m_userPromptShowCancel": true,
+        "m_userPromptStopAfterCancel": true,
+        "m_variable": {
+          "dictionary": {
+            "entries": [],
+            "isArray": false,
+            "variableType": 4,
+            "type": "Dictionary"
+          },
+          "isActionBlockWorkingVar": true,
+          "isLocalVar": true,
+          "isSecure": false,
+          "m_booleanValue": false,
+          "m_decimalValue": 0.0,
+          "m_intValue": 0,
+          "m_name": "ha_request_body",
+          "m_stringValue": "",
+          "m_type": 2,
+          "supportsInput": false,
+          "supportsOutput": true
+        },
+        "disableLogging": false,
+        "m_SIGUID": -14047,
+        "m_classType": "SetVariableAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "disableLogging": false,
+        "m_SIGUID": -14048,
+        "m_classType": "EndIfAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "cancelPrevious": false,
+        "m_backgroundColor": -14606047,
+        "m_displayIcon": false,
+        "m_duration": 0,
+        "m_horizontalPosition": 0,
+        "m_imageName": "launcher_no_border",
+        "m_imagePackageName": "com.arlosoft.macrodroid",
+        "m_imageResourceName": "launcher_no_border",
+        "m_messageText": "{lv=ha_request_body}",
+        "m_position": 0,
+        "m_textColor": -1,
+        "m_tintIcon": false,
+        "maintainSpaces": false,
+        "useTextOnly": true,
+        "disableLogging": false,
+        "m_SIGUID": -14049,
+        "m_classType": "ToastAction",
+        "m_constraintList": [],
+        "m_isDisabled": true,
+        "m_isOrCondition": false
+      },
+      {
+        "requestConfig": {
+          "allFilesAccessPath": "",
+          "allowAnyCertificate": false,
+          "basicAuthEnabled": false,
+          "basicAuthPassword": "",
+          "basicAuthUsername": "",
+          "blockNextAction": false,
+          "clientCertEnabled": false,
+          "clientCertKeyStoreDisplayName": "",
+          "clientCertKeyStoreUri": "",
+          "clientCertPassword": "",
+          "contentBodyDynamicFileName": "",
+          "contentBodyFileDisplayName": "",
+          "contentBodyFileUri": "",
+          "contentBodyFolderDisplayName": "",
+          "contentBodyFolderUri": "",
+          "contentBodySource": 0,
+          "contentBodyText": "{lv=ha_request_body}",
+          "contentType": "application/json",
+          "followRedirects": true,
+          "headerParams": [
+            {
+              "paramName": "Authorization",
+              "paramValue": "Bearer {lv=ha_token}"
+            }
+          ],
+          "localFileUri": "",
+          "prettifyJson": true,
+          "queryParams": [],
+          "requestTimeOutSeconds": 30,
+          "requestType": 1,
+          "responseVariableName": "ha_http_response",
+          "saveResponseAllFilesAccessPath": "",
+          "saveResponseFileName": "",
+          "saveResponseFolderPathDisplayName": "",
+          "saveResponseFolderPathUri": "",
+          "saveResponseType": 1,
+          "saveResponseUseAllFilesAccess": false,
+          "saveReturnCodeToVariable": false,
+          "saveReturnHeadersToVariable": false,
+          "urlToOpen": "{lv=ha_url}/api/states/sensor.{lv=ha_sensor_name}",
+          "useAllFilesAccess": false,
+          "useLocalFileUri": false,
+          "useStaticContentBodyFile": true
+        },
+        "disableLogging": false,
+        "m_SIGUID": -14050,
+        "m_classType": "HttpRequestAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "requestConfig": {
+          "allFilesAccessPath": "",
+          "allowAnyCertificate": false,
+          "basicAuthEnabled": false,
+          "basicAuthPassword": "",
+          "basicAuthUsername": "",
+          "blockNextAction": false,
+          "clientCertEnabled": false,
+          "clientCertKeyStoreDisplayName": "",
+          "clientCertKeyStoreUri": "",
+          "clientCertPassword": "",
+          "contentBodyDynamicFileName": "",
+          "contentBodyFileDisplayName": "",
+          "contentBodyFileUri": "",
+          "contentBodyFolderDisplayName": "",
+          "contentBodyFolderUri": "",
+          "contentBodySource": 0,
+          "contentBodyText": "{\n  \"state\": \"{lv=charge_status}\",\n  \"attributes\": {\n    \"friendly_name\": \"Leapmotor B10 Ladestatus\",\n    \"icon\": \"mdi:ev-plug-type2\"\n  },\n  \"force_update\": true\n}",
+          "contentType": "application/json",
+          "followRedirects": true,
+          "headerParams": [
+            {
+              "paramName": "Authorization",
+              "paramValue": "Bearer {lv=ha_token}"
+            }
+          ],
+          "localFileUri": "",
+          "prettifyJson": true,
+          "queryParams": [],
+          "requestTimeOutSeconds": 30,
+          "requestType": 1,
+          "responseVariableName": "ha_http_response",
+          "saveResponseAllFilesAccessPath": "",
+          "saveResponseFileName": "",
+          "saveResponseFolderPathDisplayName": "",
+          "saveResponseFolderPathUri": "",
+          "saveResponseType": 1,
+          "saveResponseUseAllFilesAccess": false,
+          "saveReturnCodeToVariable": false,
+          "saveReturnHeadersToVariable": false,
+          "urlToOpen": "{lv=ha_url}/api/states/sensor.leapmotor_b10_charge_status",
+          "useAllFilesAccess": false,
+          "useLocalFileUri": false,
+          "useStaticContentBodyFile": true
+        },
+        "disableLogging": false,
+        "m_SIGUID": -14051,
+        "m_classType": "HttpRequestAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "cancelPrevious": false,
+        "m_backgroundColor": -14606047,
+        "m_displayIcon": false,
+        "m_duration": 0,
+        "m_horizontalPosition": 0,
+        "m_imageName": "launcher_no_border",
+        "m_imagePackageName": "com.arlosoft.macrodroid",
+        "m_imageResourceName": "launcher_no_border",
+        "m_messageText": "{lv=ha_http_response}",
+        "m_position": 0,
+        "m_textColor": -1,
+        "m_tintIcon": false,
+        "maintainSpaces": false,
+        "useTextOnly": true,
+        "disableLogging": false,
+        "m_SIGUID": -14052,
+        "m_classType": "ToastAction",
+        "m_constraintList": [],
+        "m_isDisabled": true,
+        "m_isOrCondition": false
+      },
+      {
+        "m_applicationNameList": [
+          "Leapmotor"
+        ],
+        "m_packageNameList": [
+          "com.leapmotorinternational.global"
+        ],
+        "option": 0,
+        "disableLogging": false,
+        "m_SIGUID": -14053,
+        "m_classType": "KillBackgroundAppAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "launchByPackageName": "{lv=current_app}",
+        "m_excludeFromRecents": false,
+        "m_startNew": false,
+        "option": 1,
+        "disableLogging": false,
+        "m_SIGUID": -14054,
+        "m_classType": "LaunchActivityAction",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      }
+    ],
+    "m_category": "Uncategorized",
+    "m_constraintList": [
+      {
+        "checkThisMacro": true,
+        "m_invoked": false,
+        "m_macroIds": [],
+        "m_macroNames": [],
+        "m_timePeriodSeconds": 285,
+        "disableLogging": false,
+        "m_SIGUID": -7090,
+        "m_classType": "LastRunTimeConstraint",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "m_locked": false,
+        "disableLogging": false,
+        "m_SIGUID": -7091,
+        "m_classType": "DeviceLockedConstraint",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      }
+    ],
+    "m_description": "Sendet Fahrzeugdaten an Home Assistant inkl. Ladestatus A/B/C.",
+    "m_descriptionOpen": false,
+    "m_enabled": true,
+    "m_excludeLog": false,
+    "m_headingColor": 0,
+    "m_isOrCondition": false,
+    "m_name": "Leapmotor to Home Assistant",
+    "m_triggerList": [
+      {
+        "m_screenOn": false,
+        "disableLogging": false,
+        "m_SIGUID": -7092,
+        "m_classType": "ScreenOnOffTrigger",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      },
+      {
+        "m_ignoreReferenceStartTime": false,
+        "m_minutes": 0,
+        "m_seconds": 300,
+        "m_startHour": 0,
+        "m_startMinute": 0,
+        "m_useAlarm": true,
+        "m_useIntervalVariable": false,
+        "m_useReferenceTimeVariable": false,
+        "disableLogging": false,
+        "m_SIGUID": -7093,
+        "m_classType": "RegularIntervalTrigger",
+        "m_constraintList": [],
+        "m_isDisabled": false,
+        "m_isOrCondition": false
+      }
+    ]
+  },
+  "macroExportVersion": 1
+}

--- a/Leapmotor_to_HomeAssistant_B10.macro
+++ b/Leapmotor_to_HomeAssistant_B10.macro
@@ -8,7 +8,7 @@
     "isActionBlock": false,
     "isExtra": false,
     "isFavourite": false,
-    "lastEditedTimestamp": 1775880000900,
+    "lastEditedTimestamp": 1776259421670,
     "localVariables": [
       {
         "dictionary": {
@@ -30,6 +30,7 @@
         "supportsOutput": true
       },
       {
+        "description": "",
         "dictionary": {
           "entries": [],
           "isArray": false,
@@ -68,6 +69,7 @@
         "supportsOutput": true
       },
       {
+        "description": "",
         "dictionary": {
           "entries": [],
           "isArray": false,
@@ -126,9 +128,564 @@
       },
       {
         "dictionary": {
-          "entries": [],
+          "entries": [
+            {
+              "key": "com.arlosoft.macrodroid:id/exportdialog_filename",
+              "variable": {
+                "entries": [
+                  {
+                    "key": "text",
+                    "variable": {
+                      "textValue": "MacroDroid_26_04_23_05_28",
+                      "variableType": 2,
+                      "type": "StringValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "centerX",
+                    "variable": {
+                      "intValue": 315,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "centerY",
+                    "variable": {
+                      "intValue": 767,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "startX",
+                    "variable": {
+                      "intValue": 72,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "startY",
+                    "variable": {
+                      "intValue": 722,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "endX",
+                    "variable": {
+                      "intValue": 558,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "endY",
+                    "variable": {
+                      "intValue": 813,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "bounds",
+                    "variable": {
+                      "textValue": "(72, 722) - (558, 813)",
+                      "variableType": 2,
+                      "type": "StringValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  }
+                ],
+                "isArray": false,
+                "variableType": 4,
+                "type": "Dictionary"
+              },
+              "variableType": 11,
+              "type": "DictionaryEntry"
+            },
+            {
+              "key": "com.arlosoft.macrodroid:id/fileExtension",
+              "variable": {
+                "entries": [
+                  {
+                    "key": "text",
+                    "variable": {
+                      "textValue": ".mdr",
+                      "variableType": 2,
+                      "type": "StringValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "centerX",
+                    "variable": {
+                      "intValue": 603,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "centerY",
+                    "variable": {
+                      "intValue": 772,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "startX",
+                    "variable": {
+                      "intValue": 566,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "startY",
+                    "variable": {
+                      "intValue": 748,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "endX",
+                    "variable": {
+                      "intValue": 640,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "endY",
+                    "variable": {
+                      "intValue": 797,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "bounds",
+                    "variable": {
+                      "textValue": "(566, 748) - (640, 797)",
+                      "variableType": 2,
+                      "type": "StringValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  }
+                ],
+                "isArray": false,
+                "variableType": 4,
+                "type": "Dictionary"
+              },
+              "variableType": 11,
+              "type": "DictionaryEntry"
+            },
+            {
+              "key": "com.arlosoft.macrodroid:id/encrypt_output_checkbox",
+              "variable": {
+                "entries": [
+                  {
+                    "key": "text",
+                    "variable": {
+                      "textValue": "Ausgabedatei verschl\u00fcsseln",
+                      "variableType": 2,
+                      "type": "StringValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "centerX",
+                    "variable": {
+                      "intValue": 277,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "centerY",
+                    "variable": {
+                      "intValue": 636,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "startX",
+                    "variable": {
+                      "intValue": 72,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "startY",
+                    "variable": {
+                      "intValue": 604,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "endX",
+                    "variable": {
+                      "intValue": 483,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "endY",
+                    "variable": {
+                      "intValue": 668,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "bounds",
+                    "variable": {
+                      "textValue": "(72, 604) - (483, 668)",
+                      "variableType": 2,
+                      "type": "StringValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  }
+                ],
+                "isArray": false,
+                "variableType": 4,
+                "type": "Dictionary"
+              },
+              "variableType": 11,
+              "type": "DictionaryEntry"
+            },
+            {
+              "key": "com.arlosoft.macrodroid:id/cancelButton",
+              "variable": {
+                "entries": [
+                  {
+                    "key": "text",
+                    "variable": {
+                      "textValue": "ABBRECHEN",
+                      "variableType": 2,
+                      "type": "StringValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "centerX",
+                    "variable": {
+                      "intValue": 415,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "centerY",
+                    "variable": {
+                      "intValue": 861,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "startX",
+                    "variable": {
+                      "intValue": 310,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "startY",
+                    "variable": {
+                      "intValue": 813,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "endX",
+                    "variable": {
+                      "intValue": 520,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "endY",
+                    "variable": {
+                      "intValue": 909,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "bounds",
+                    "variable": {
+                      "textValue": "(310, 813) - (520, 909)",
+                      "variableType": 2,
+                      "type": "StringValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  }
+                ],
+                "isArray": false,
+                "variableType": 4,
+                "type": "Dictionary"
+              },
+              "variableType": 11,
+              "type": "DictionaryEntry"
+            },
+            {
+              "key": "com.arlosoft.macrodroid:id/okButton",
+              "variable": {
+                "entries": [
+                  {
+                    "key": "text",
+                    "variable": {
+                      "textValue": "OK",
+                      "variableType": 2,
+                      "type": "StringValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "centerX",
+                    "variable": {
+                      "intValue": 600,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "centerY",
+                    "variable": {
+                      "intValue": 861,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "startX",
+                    "variable": {
+                      "intValue": 520,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "startY",
+                    "variable": {
+                      "intValue": 813,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "endX",
+                    "variable": {
+                      "intValue": 680,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "endY",
+                    "variable": {
+                      "intValue": 909,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "bounds",
+                    "variable": {
+                      "textValue": "(520, 813) - (680, 909)",
+                      "variableType": 2,
+                      "type": "StringValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  }
+                ],
+                "isArray": false,
+                "variableType": 4,
+                "type": "Dictionary"
+              },
+              "variableType": 11,
+              "type": "DictionaryEntry"
+            },
+            {
+              "key": "com.arlosoft.macrodroid:id/title",
+              "variable": {
+                "entries": [
+                  {
+                    "key": "text",
+                    "variable": {
+                      "textValue": "Android \"Share\"",
+                      "variableType": 2,
+                      "type": "StringValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "centerX",
+                    "variable": {
+                      "intValue": 360,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "centerY",
+                    "variable": {
+                      "intValue": 519,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "startX",
+                    "variable": {
+                      "intValue": 32,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "startY",
+                    "variable": {
+                      "intValue": 474,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "endX",
+                    "variable": {
+                      "intValue": 688,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "endY",
+                    "variable": {
+                      "intValue": 564,
+                      "variableType": 1,
+                      "type": "IntegerValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  },
+                  {
+                    "key": "bounds",
+                    "variable": {
+                      "textValue": "(32, 474) - (688, 564)",
+                      "variableType": 2,
+                      "type": "StringValue"
+                    },
+                    "variableType": 11,
+                    "type": "DictionaryEntry"
+                  }
+                ],
+                "isArray": false,
+                "variableType": 4,
+                "type": "Dictionary"
+              },
+              "variableType": 11,
+              "type": "DictionaryEntry"
+            }
+          ],
           "isArray": false,
+          "parents": [],
           "variableType": 4,
+          "parentKeys": [],
           "type": "Dictionary"
         },
         "isActionBlockWorkingVar": false,
@@ -271,7 +828,7 @@
         "m_decimalValue": 0.0,
         "m_intValue": 0,
         "m_name": "tvOdometer",
-        "m_stringValue": "0",
+        "m_stringValue": "",
         "m_type": 2,
         "supportsInput": false,
         "supportsOutput": true
@@ -309,7 +866,7 @@
         "m_decimalValue": 0.0,
         "m_intValue": 0,
         "m_name": "tv_charge_power",
-        "m_stringValue": "0",
+        "m_stringValue": "",
         "m_type": 2,
         "supportsInput": false,
         "supportsOutput": true
@@ -366,12 +923,33 @@
         "m_decimalValue": 0.0,
         "m_intValue": 0,
         "m_name": "charge_status",
-        "m_stringValue": "A",
+        "m_stringValue": "",
+        "m_type": 2,
+        "supportsInput": false,
+        "supportsOutput": true
+      },
+      {
+        "dictionary": {
+          "entries": [],
+          "isArray": false,
+          "variableType": 4,
+          "type": "Dictionary"
+        },
+        "isActionBlockWorkingVar": false,
+        "isLocalVar": true,
+        "isSecure": false,
+        "m_booleanValue": false,
+        "m_decimalValue": 0.0,
+        "m_intValue": 0,
+        "m_name": "tv_charge_remaining_str",
+        "m_stringValue": "",
         "m_type": 2,
         "supportsInput": false,
         "supportsOutput": true
       }
     ],
+    "localVarsAlphabetical": true,
+    "m_GUID": -7756093140135957331,
     "m_actionList": [
       {
         "booleanDictionaryKeys": {
@@ -421,7 +999,7 @@
           "supportsOutput": true
         },
         "disableLogging": false,
-        "m_SIGUID": -14001,
+        "m_SIGUID": -8820944076811840686,
         "m_classType": "SetVariableAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -434,7 +1012,7 @@
         "m_startNew": true,
         "option": 0,
         "disableLogging": false,
-        "m_SIGUID": -14002,
+        "m_SIGUID": -5836404855900243805,
         "m_classType": "LaunchActivityAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -446,7 +1024,7 @@
         "m_useAlarm": false,
         "unitForVariables": 0,
         "disableLogging": false,
-        "m_SIGUID": -14003,
+        "m_SIGUID": -7269358796148886172,
         "m_classType": "PauseAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -458,7 +1036,7 @@
         "childrenCollapsed": false,
         "dontLogIfConditionIsFalse": false,
         "disableLogging": false,
-        "m_SIGUID": -14003,
+        "m_SIGUID": -5652282733776394412,
         "m_classType": "LoopAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -475,7 +1053,7 @@
         "isLocalVar": true,
         "variableName": "screen_contents",
         "disableLogging": false,
-        "m_SIGUID": -14004,
+        "m_SIGUID": -5792112546212628513,
         "m_classType": "ReadScreenContentsAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -485,7 +1063,7 @@
         "childrenCollapsed": false,
         "dontLogIfConditionIsFalse": false,
         "disableLogging": false,
-        "m_SIGUID": -14005,
+        "m_SIGUID": -5792830075558586356,
         "m_classType": "IfConditionAction",
         "m_constraintList": [
           {
@@ -528,7 +1106,7 @@
               "supportsOutput": true
             },
             "disableLogging": false,
-            "m_SIGUID": -14006,
+            "m_SIGUID": -4852809313188097238,
             "m_classType": "MacroDroidVariableConstraint",
             "m_constraintList": [],
             "m_isDisabled": false,
@@ -540,7 +1118,7 @@
       },
       {
         "disableLogging": false,
-        "m_SIGUID": -14007,
+        "m_SIGUID": -5748360067954206898,
         "m_classType": "BreakFromLoopAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -548,7 +1126,7 @@
       },
       {
         "disableLogging": false,
-        "m_SIGUID": -14008,
+        "m_SIGUID": -7140209771573257400,
         "m_classType": "EndIfAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -560,7 +1138,7 @@
         "m_useAlarm": false,
         "unitForVariables": 0,
         "disableLogging": false,
-        "m_SIGUID": -14009,
+        "m_SIGUID": -7008904495359168390,
         "m_classType": "PauseAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -568,7 +1146,7 @@
       },
       {
         "disableLogging": false,
-        "m_SIGUID": -14010,
+        "m_SIGUID": -4702529773919789572,
         "m_classType": "EndLoopAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -576,7 +1154,7 @@
       },
       {
         "m_option": 2,
-        "m_text": "{lv=screen_contents[com.leapmotorinternational.global:id/tvHomeAirTemp1][text]}",
+        "m_text": "{lv=screen_contents[com.leapmotorinternational.global:id/tvHomeAirTemp][text]}",
         "m_textManipulation": {
           "type": "ExtractTextManipulation",
           "params": [
@@ -586,7 +1164,7 @@
         },
         "variableName": "tvHomeAirTemp1",
         "disableLogging": false,
-        "m_SIGUID": -14011,
+        "m_SIGUID": -5981712766689555728,
         "m_classType": "TextManipulationAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -594,7 +1172,7 @@
       },
       {
         "m_option": 2,
-        "m_text": "{lv=screen_contents[com.leapmotorinternational.global:id/tvHomeCarTemp1][text]}",
+        "m_text": "{lv=screen_contents[com.leapmotorinternational.global:id/tvHomeCarTemp][text]}",
         "m_textManipulation": {
           "type": "ExtractTextManipulation",
           "params": [
@@ -604,7 +1182,7 @@
         },
         "variableName": "tvHomeCarTemp1",
         "disableLogging": false,
-        "m_SIGUID": -14012,
+        "m_SIGUID": -5614609514692850126,
         "m_classType": "TextManipulationAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -622,7 +1200,7 @@
         },
         "variableName": "tvRemainMileage",
         "disableLogging": false,
-        "m_SIGUID": -14013,
+        "m_SIGUID": -8327218528094343384,
         "m_classType": "TextManipulationAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -676,7 +1254,7 @@
           "supportsOutput": true
         },
         "disableLogging": false,
-        "m_SIGUID": -14014,
+        "m_SIGUID": -4852264938008445115,
         "m_classType": "SetVariableAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -686,7 +1264,7 @@
         "childrenCollapsed": false,
         "dontLogIfConditionIsFalse": false,
         "disableLogging": false,
-        "m_SIGUID": -14061,
+        "m_SIGUID": -7934306933054469994,
         "m_classType": "IfConditionAction",
         "m_constraintList": [
           {
@@ -722,11 +1300,11 @@
               "m_name": "tvCarState",
               "m_stringValue": "",
               "m_type": 2,
-              "supportsInput": false,
+              "supportsInput": true,
               "supportsOutput": true
             },
             "disableLogging": false,
-            "m_SIGUID": -14062,
+            "m_SIGUID": -5966731877373952133,
             "m_classType": "MacroDroidVariableConstraint",
             "m_constraintList": [],
             "m_isDisabled": false,
@@ -784,15 +1362,16 @@
           "supportsOutput": true
         },
         "disableLogging": false,
-        "m_SIGUID": -14063,
+        "m_SIGUID": -6568264470896687632,
         "m_classType": "SetVariableAction",
         "m_constraintList": [],
         "m_isDisabled": false,
         "m_isOrCondition": false
       },
       {
+        "dontLogIfConditionIsFalse": false,
         "disableLogging": false,
-        "m_SIGUID": -14064,
+        "m_SIGUID": -6024478457050972396,
         "m_classType": "ElseAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -846,7 +1425,7 @@
           "supportsOutput": true
         },
         "disableLogging": false,
-        "m_SIGUID": -14015,
+        "m_SIGUID": -6125240109509739126,
         "m_classType": "SetVariableAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -854,40 +1433,62 @@
       },
       {
         "disableLogging": false,
-        "m_SIGUID": -14065,
+        "m_SIGUID": -5313604061857434883,
         "m_classType": "EndIfAction",
         "m_constraintList": [],
         "m_isDisabled": false,
         "m_isOrCondition": false
       },
       {
-        "action": 0,
-        "uiInteractionConfiguration": {
-          "blocking": true,
-          "checkOverlays": false,
-          "clickOption": 0,
-          "contentDescription": "",
-          "longClick": false,
-          "skipCount": "0",
-          "textContent": "",
-          "textMatchOption": 0,
-          "useRegex": false,
-          "viewId": "",
-          "xyPercentages": true,
-          "xyPoint": {
-            "x": 0,
-            "y": 0
+        "booleanDictionaryKeys": {
+          "keys": []
+        },
+        "dictionaryKeys": [],
+        "dictionaryOrArrayType": -1,
+        "existingManualKeyType": 0,
+        "m_booleanInvert": false,
+        "m_darkMode": -1,
+        "m_doubleRandomMax": 0.0,
+        "m_doubleRandomMin": 0.0,
+        "m_falseLabel": "False",
+        "m_intExpression": false,
+        "m_intRandom": false,
+        "m_intRandomMax": 0,
+        "m_intRandomMin": 0,
+        "m_intValueDecrement": false,
+        "m_intValueIncrement": false,
+        "m_newBooleanValue": false,
+        "m_newDoubleValue": 0.0,
+        "m_newIntValue": 0,
+        "m_newStringValue": "{lv=screen_contents[com.leapmotorinternational.global:id/tvLpCarHomeCharge][text]}",
+        "m_trueLabel": "True",
+        "m_userPrompt": false,
+        "m_userPromptEmptyAtStart": false,
+        "m_userPromptPassword": false,
+        "m_userPromptShowCancel": true,
+        "m_userPromptStopAfterCancel": true,
+        "m_variable": {
+          "dictionary": {
+            "entries": [],
+            "isArray": false,
+            "variableType": 4,
+            "type": "Dictionary"
           },
-          "startXPercent": 50,
-          "startYPercent": 75,
-          "endXPercent": 50,
-          "endYPercent": 25,
-          "duration": 500,
-          "type": "Swipe"
+          "isActionBlockWorkingVar": false,
+          "isLocalVar": true,
+          "isSecure": false,
+          "m_booleanValue": false,
+          "m_decimalValue": 0.0,
+          "m_intValue": 0,
+          "m_name": "tv_charge_remaining_str",
+          "m_stringValue": "",
+          "m_type": 2,
+          "supportsInput": false,
+          "supportsOutput": true
         },
         "disableLogging": false,
-        "m_SIGUID": -14016,
-        "m_classType": "UIInteractionAction",
+        "m_SIGUID": -5022152180312161302,
+        "m_classType": "SetVariableAction",
         "m_constraintList": [],
         "m_isDisabled": false,
         "m_isOrCondition": false
@@ -898,7 +1499,7 @@
         "m_useAlarm": false,
         "unitForVariables": 0,
         "disableLogging": false,
-        "m_SIGUID": -14017,
+        "m_SIGUID": -6354540978498770725,
         "m_classType": "PauseAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -915,7 +1516,7 @@
         "isLocalVar": true,
         "variableName": "screen_contents",
         "disableLogging": false,
-        "m_SIGUID": -14018,
+        "m_SIGUID": -5388244995882399604,
         "m_classType": "ReadScreenContentsAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -933,7 +1534,7 @@
         },
         "variableName": "tvOdometer",
         "disableLogging": false,
-        "m_SIGUID": -14019,
+        "m_SIGUID": -6288450170004145042,
         "m_classType": "TextManipulationAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -960,7 +1561,7 @@
           "type": "Click"
         },
         "disableLogging": false,
-        "m_SIGUID": -14020,
+        "m_SIGUID": -6691815647162137719,
         "m_classType": "UIInteractionAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -972,7 +1573,7 @@
         "childrenCollapsed": false,
         "dontLogIfConditionIsFalse": false,
         "disableLogging": false,
-        "m_SIGUID": -14021,
+        "m_SIGUID": -8160311380667214700,
         "m_classType": "LoopAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -989,7 +1590,7 @@
         "isLocalVar": true,
         "variableName": "screen_contents",
         "disableLogging": false,
-        "m_SIGUID": -14022,
+        "m_SIGUID": -6887301513876395323,
         "m_classType": "ReadScreenContentsAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -999,7 +1600,7 @@
         "childrenCollapsed": false,
         "dontLogIfConditionIsFalse": false,
         "disableLogging": false,
-        "m_SIGUID": -14023,
+        "m_SIGUID": -5447457587457503745,
         "m_classType": "IfConditionAction",
         "m_constraintList": [
           {
@@ -1042,7 +1643,7 @@
               "supportsOutput": true
             },
             "disableLogging": false,
-            "m_SIGUID": -14024,
+            "m_SIGUID": -6686570490373073167,
             "m_classType": "MacroDroidVariableConstraint",
             "m_constraintList": [],
             "m_isDisabled": false,
@@ -1064,7 +1665,7 @@
         },
         "variableName": "tv_soc",
         "disableLogging": false,
-        "m_SIGUID": -14025,
+        "m_SIGUID": -6992635264633211758,
         "m_classType": "TextManipulationAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1072,7 +1673,7 @@
       },
       {
         "disableLogging": false,
-        "m_SIGUID": -14027,
+        "m_SIGUID": -5871829849997180568,
         "m_classType": "BreakFromLoopAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1080,7 +1681,7 @@
       },
       {
         "disableLogging": false,
-        "m_SIGUID": -14028,
+        "m_SIGUID": -9108167336913467205,
         "m_classType": "EndIfAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1092,7 +1693,7 @@
         "m_useAlarm": false,
         "unitForVariables": 0,
         "disableLogging": false,
-        "m_SIGUID": -14029,
+        "m_SIGUID": -8502516852308229565,
         "m_classType": "PauseAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1100,7 +1701,7 @@
       },
       {
         "disableLogging": false,
-        "m_SIGUID": -14030,
+        "m_SIGUID": -5705446039970684874,
         "m_classType": "EndLoopAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1117,7 +1718,7 @@
         "isLocalVar": true,
         "variableName": "screen_contents",
         "disableLogging": false,
-        "m_SIGUID": -14031,
+        "m_SIGUID": -6846169100837250526,
         "m_classType": "ReadScreenContentsAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1135,7 +1736,7 @@
         },
         "variableName": "tv_charge_limit",
         "disableLogging": false,
-        "m_SIGUID": -14036,
+        "m_SIGUID": -6363485881375587805,
         "m_classType": "TextManipulationAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1145,7 +1746,7 @@
         "childrenCollapsed": false,
         "dontLogIfConditionIsFalse": false,
         "disableLogging": false,
-        "m_SIGUID": -14032,
+        "m_SIGUID": -6066321282169141868,
         "m_classType": "IfConditionAction",
         "m_constraintList": [
           {
@@ -1188,7 +1789,7 @@
               "supportsOutput": true
             },
             "disableLogging": false,
-            "m_SIGUID": -14033,
+            "m_SIGUID": -8720064430018643957,
             "m_classType": "MacroDroidVariableConstraint",
             "m_constraintList": [],
             "m_isDisabled": false,
@@ -1204,13 +1805,13 @@
         "m_textManipulation": {
           "type": "ExtractTextManipulation",
           "params": [
-            "[0-9,\\.]+",
+            "\\d+[.,]?\\d*",
             "0"
           ]
         },
         "variableName": "tv_charge_current",
         "disableLogging": false,
-        "m_SIGUID": -14034,
+        "m_SIGUID": -5525668590309708614,
         "m_classType": "TextManipulationAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1218,31 +1819,17 @@
       },
       {
         "m_option": 2,
-        "m_text": "{lv=screen_contents[com.leapmotorinternational.global:id/tv_power2][text]}",
+        "m_text": "{lv=screen_contents[com.leapmotorinternational.global:id/tv_power][text]}",
         "m_textManipulation": {
           "type": "ExtractTextManipulation",
           "params": [
-            "[0-9,\\.]+",
+            "\\d+[.,]?\\d*",
             "0"
           ]
         },
         "variableName": "tv_charge_power",
         "disableLogging": false,
-        "m_SIGUID": -14035,
-        "m_classType": "TextManipulationAction",
-        "m_constraintList": [],
-        "m_isDisabled": false,
-        "m_isOrCondition": false
-      },
-      {
-        "m_option": 2,
-        "m_text": "{lv=screen_contents[com.leapmotorinternational.global:id/tv_charge_state][text]}",
-        "m_textManipulation": {
-          "type": "NoManipulation"
-        },
-        "variableName": "tv_charge_remaining",
-        "disableLogging": false,
-        "m_SIGUID": -14026,
+        "m_SIGUID": -9159754323831241397,
         "m_classType": "TextManipulationAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1252,7 +1839,7 @@
         "childrenCollapsed": false,
         "dontLogIfConditionIsFalse": false,
         "disableLogging": false,
-        "m_SIGUID": -14037,
+        "m_SIGUID": -6401818392046880107,
         "m_classType": "IfConditionAction",
         "m_constraintList": [
           {
@@ -1295,7 +1882,7 @@
               "supportsOutput": true
             },
             "disableLogging": false,
-            "m_SIGUID": -14038,
+            "m_SIGUID": -7299297201949011636,
             "m_classType": "MacroDroidVariableConstraint",
             "m_constraintList": [],
             "m_isDisabled": false,
@@ -1353,7 +1940,7 @@
           "supportsOutput": true
         },
         "disableLogging": false,
-        "m_SIGUID": -14039,
+        "m_SIGUID": -6355034441669771193,
         "m_classType": "SetVariableAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1380,7 +1967,7 @@
         "m_newBooleanValue": false,
         "m_newDoubleValue": 0.0,
         "m_newIntValue": 0,
-        "m_newStringValue": "{\n  \"state\": \"Charging\",\n  \"attributes\": {\n    \"battery_percent\": {lv=tv_soc},\n    \"charge_current_a\": \"{lv=tv_charge_current}\",\n    \"charge_power_kw\": \"{lv=tv_charge_power}\",\n    \"charge_limit_percent\": {lv=tv_charge_limit},\n    \"charge_remaining\": \"{lv=tv_charge_remaining}\",\n    \"air_temp\": {lv=tvHomeAirTemp1},\n    \"car_temp\": {lv=tvHomeCarTemp1},\n    \"lock_state\": \"{lv=tvCarLockState}\",\n    \"remaining_range\": {lv=tvRemainMileage},\n    \"odometer\": \"{lv=tvOdometer}\",\n    \"friendly_name\": \"Leapmotor B10\",\n    \"icon\": \"mdi:car-electric\"\n  },\n  \"force_update\": true\n}",
+        "m_newStringValue": "{\n  \"state\": \"Charging\",\n  \"attributes\": {\n    \"battery_percent\": {lv=tv_soc},\n    \"charge_current_a\": \"{lv=tv_charge_current}\",\n    \"charge_power_kw\": \"{lv=tv_charge_power}\",\n    \"charge_limit_percent\": {lv=tv_charge_limit},\n    \"charge_remaining\": \"{lv=tv_charge_remaining_str}\",\n    \"air_temp\": {lv=tvHomeAirTemp1},\n    \"car_temp\": {lv=tvHomeCarTemp1},\n    \"lock_state\": \"{lv=tvCarLockState}\",\n    \"remaining_range\": {lv=tvRemainMileage},\n    \"odometer\": \"{lv=tvOdometer}\",\n    \"friendly_name\": \"Leapmotor B10\",\n    \"icon\": \"mdi:car-electric\"\n  },\n  \"force_update\": true\n}",
         "m_trueLabel": "True",
         "m_userPrompt": false,
         "m_userPromptEmptyAtStart": false,
@@ -1407,15 +1994,16 @@
           "supportsOutput": true
         },
         "disableLogging": false,
-        "m_SIGUID": -14040,
+        "m_SIGUID": -6654615040751255719,
         "m_classType": "SetVariableAction",
         "m_constraintList": [],
         "m_isDisabled": false,
         "m_isOrCondition": false
       },
       {
+        "dontLogIfConditionIsFalse": false,
         "disableLogging": false,
-        "m_SIGUID": -14041,
+        "m_SIGUID": -5247616960314461610,
         "m_classType": "ElseAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1469,7 +2057,7 @@
           "supportsOutput": true
         },
         "disableLogging": false,
-        "m_SIGUID": -14042,
+        "m_SIGUID": -6039869709381344954,
         "m_classType": "SetVariableAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1496,7 +2084,7 @@
         "m_newBooleanValue": false,
         "m_newDoubleValue": 0.0,
         "m_newIntValue": 0,
-        "m_newStringValue": "{\n  \"state\": \"{lv=tvCarState}\",\n  \"attributes\": {\n    \"battery_percent\": {lv=tv_soc},\n    \"air_temp\": {lv=tvHomeAirTemp1},\n    \"car_temp\": {lv=tvHomeCarTemp1},\n    \"lock_state\": \"{lv=tvCarLockState}\",\n    \"remaining_range\": {lv=tvRemainMileage},\n    \"odometer\": \"{lv=tvOdometer}\",\n    \"charge_current_a\": \"0\",\n    \"charge_power_kw\": \"0\",\n    \"charge_limit_percent\": {lv=tv_charge_limit},\n    \"charge_remaining\": 0,\n    \"friendly_name\": \"Leapmotor B10\",\n    \"icon\": \"mdi:car-electric\"\n  },\n  \"force_update\": true\n}",
+        "m_newStringValue": "{\n  \"state\": \"{lv=tvCarState}\",\n  \"attributes\": {\n    \"battery_percent\": {lv=tv_soc},\n    \"air_temp\": {lv=tvHomeAirTemp1},\n    \"car_temp\": {lv=tvHomeCarTemp1},\n    \"lock_state\": \"{lv=tvCarLockState}\",\n    \"remaining_range\": {lv=tvRemainMileage},\n    \"odometer\": \"{lv=tvOdometer}\",\n    \"charge_current_a\": \"0\",\n    \"charge_power_kw\": \"0\",\n    \"charge_limit_percent\": {lv=tv_charge_limit},\n    \"charge_remaining\": \"{lv=tv_charge_remaining_str}\",\n    \"friendly_name\": \"Leapmotor B10\",\n    \"icon\": \"mdi:car-electric\"\n  },\n  \"force_update\": true\n}",
         "m_trueLabel": "True",
         "m_userPrompt": false,
         "m_userPromptEmptyAtStart": false,
@@ -1523,7 +2111,7 @@
           "supportsOutput": true
         },
         "disableLogging": false,
-        "m_SIGUID": -14043,
+        "m_SIGUID": -7502905659970581740,
         "m_classType": "SetVariableAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1531,15 +2119,16 @@
       },
       {
         "disableLogging": false,
-        "m_SIGUID": -14044,
+        "m_SIGUID": -8887607579914836282,
         "m_classType": "EndIfAction",
         "m_constraintList": [],
         "m_isDisabled": false,
         "m_isOrCondition": false
       },
       {
+        "dontLogIfConditionIsFalse": false,
         "disableLogging": false,
-        "m_SIGUID": -14045,
+        "m_SIGUID": -5657983324998298455,
         "m_classType": "ElseAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1593,7 +2182,7 @@
           "supportsOutput": true
         },
         "disableLogging": false,
-        "m_SIGUID": -14046,
+        "m_SIGUID": -7117066150192084535,
         "m_classType": "SetVariableAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1620,7 +2209,7 @@
         "m_newBooleanValue": false,
         "m_newDoubleValue": 0.0,
         "m_newIntValue": 0,
-        "m_newStringValue": "{\n  \"state\": \"{lv=tvCarState}\",\n  \"attributes\": {\n    \"battery_percent\": {lv=tv_soc},\n    \"air_temp\": {lv=tvHomeAirTemp1},\n    \"car_temp\": {lv=tvHomeCarTemp1},\n    \"lock_state\": \"{lv=tvCarLockState}\",\n    \"remaining_range\": {lv=tvRemainMileage},\n    \"odometer\": \"{lv=tvOdometer}\",\n    \"charge_current_a\": \"0\",\n    \"charge_power_kw\": \"0\",\n    \"charge_limit_percent\": {lv=tv_charge_limit},\n    \"charge_remaining\": 0,\n    \"friendly_name\": \"Leapmotor B10\",\n    \"icon\": \"mdi:car-electric\"\n  },\n  \"force_update\": true\n}",
+        "m_newStringValue": "{\n  \"state\": \"{lv=tvCarState}\",\n  \"attributes\": {\n    \"battery_percent\": {lv=tv_soc},\n    \"air_temp\": {lv=tvHomeAirTemp1},\n    \"car_temp\": {lv=tvHomeCarTemp1},\n    \"lock_state\": \"{lv=tvCarLockState}\",\n    \"remaining_range\": {lv=tvRemainMileage},\n    \"odometer\": \"{lv=tvOdometer}\",\n    \"charge_current_a\": \"0\",\n    \"charge_power_kw\": \"0\",\n    \"charge_limit_percent\": {lv=tv_charge_limit},\n    \"charge_remaining\": \"{lv=tv_charge_remaining_str}\",\n    \"friendly_name\": \"Leapmotor B10\",\n    \"icon\": \"mdi:car-electric\"\n  },\n  \"force_update\": true\n}",
         "m_trueLabel": "True",
         "m_userPrompt": false,
         "m_userPromptEmptyAtStart": false,
@@ -1647,7 +2236,7 @@
           "supportsOutput": true
         },
         "disableLogging": false,
-        "m_SIGUID": -14047,
+        "m_SIGUID": -7580202805928629753,
         "m_classType": "SetVariableAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1655,7 +2244,7 @@
       },
       {
         "disableLogging": false,
-        "m_SIGUID": -14048,
+        "m_SIGUID": -7172690110179279850,
         "m_classType": "EndIfAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1677,7 +2266,7 @@
         "maintainSpaces": false,
         "useTextOnly": true,
         "disableLogging": false,
-        "m_SIGUID": -14049,
+        "m_SIGUID": -8078425774093825966,
         "m_classType": "ToastAction",
         "m_constraintList": [],
         "m_isDisabled": true,
@@ -1730,7 +2319,7 @@
           "useStaticContentBodyFile": true
         },
         "disableLogging": false,
-        "m_SIGUID": -14050,
+        "m_SIGUID": -6886939751772189221,
         "m_classType": "HttpRequestAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1783,7 +2372,7 @@
           "useStaticContentBodyFile": true
         },
         "disableLogging": false,
-        "m_SIGUID": -14051,
+        "m_SIGUID": -9156074251278901770,
         "m_classType": "HttpRequestAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1805,7 +2394,7 @@
         "maintainSpaces": false,
         "useTextOnly": true,
         "disableLogging": false,
-        "m_SIGUID": -14052,
+        "m_SIGUID": -7326721925585539065,
         "m_classType": "ToastAction",
         "m_constraintList": [],
         "m_isDisabled": true,
@@ -1820,7 +2409,7 @@
         ],
         "option": 0,
         "disableLogging": false,
-        "m_SIGUID": -14053,
+        "m_SIGUID": -7937168196456114756,
         "m_classType": "KillBackgroundAppAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1832,7 +2421,7 @@
         "m_startNew": false,
         "option": 1,
         "disableLogging": false,
-        "m_SIGUID": -14054,
+        "m_SIGUID": -9195427692634849296,
         "m_classType": "LaunchActivityAction",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1848,7 +2437,7 @@
         "m_macroNames": [],
         "m_timePeriodSeconds": 285,
         "disableLogging": false,
-        "m_SIGUID": -7090,
+        "m_SIGUID": -8552302909900963729,
         "m_classType": "LastRunTimeConstraint",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1857,7 +2446,7 @@
       {
         "m_locked": false,
         "disableLogging": false,
-        "m_SIGUID": -7091,
+        "m_SIGUID": -7995757414991679901,
         "m_classType": "DeviceLockedConstraint",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1870,12 +2459,12 @@
     "m_excludeLog": false,
     "m_headingColor": 0,
     "m_isOrCondition": false,
-    "m_name": "Leapmotor to Home Assistant",
+    "m_name": "Leapmotor to Home Assistant B10",
     "m_triggerList": [
       {
         "m_screenOn": false,
         "disableLogging": false,
-        "m_SIGUID": -7092,
+        "m_SIGUID": -4712074265133578165,
         "m_classType": "ScreenOnOffTrigger",
         "m_constraintList": [],
         "m_isDisabled": false,
@@ -1891,7 +2480,7 @@
         "m_useIntervalVariable": false,
         "m_useReferenceTimeVariable": false,
         "disableLogging": false,
-        "m_SIGUID": -7093,
+        "m_SIGUID": -5502561424966636476,
         "m_classType": "RegularIntervalTrigger",
         "m_constraintList": [],
         "m_isDisabled": false,

--- a/README.md
+++ b/README.md
@@ -21,6 +21,57 @@ The integration tracks the following vehicle data:
 - Interior temperature
 - Exterior temperature
 
+## Leapmotor B10 Support
+
+A B10-specific macro (`Leapmotor_to_HomeAssistant_B10.macro`) and sensor configuration (`sensor_b10.yaml`) are available with extended functionality.
+
+### Additional Data Points
+
+Compared to the C10 integration, the B10 macro additionally tracks:
+
+* Odometer (total km driven)
+* Charge limit (%)
+* Charge current (A)
+* Charge power (kW)
+* Charge remaining time
+* Charge status (A = not connected, B = connected/not charging, C = charging)
+
+### Charge Status Logic
+
+The B10 macro distinguishes three charging states and sends them to a separate sensor (`sensor.leapmotor_b10_charge_status`):
+
+* **A** – Not connected
+* **B** – Connected, not charging
+* **C** – Actively charging (charge current, power and remaining time are read from the app)
+
+Charge limit is always read and transmitted regardless of charge status.
+
+The A/B/C status is designed to be compatible with [evcc](https://evcc.io/) for smart charging control.
+
+> **Note:** Charge remaining time (`charge_remaining`) is not yet fully implemented — it is transmitted as `0` for status A and B. Live readout during active charging (status C) is pending real-world testing.
+
+### Trigger & Update Frequency
+
+The B10 macro runs on two triggers:
+
+* Screen turns off
+* Every 5 minutes (regular interval)
+
+The minimum interval between runs is ~5 minutes (constraint: 285 seconds).
+
+### Setup
+
+Follow the same installation steps as for the C10, with these differences:
+
+* Import `Leapmotor_to_HomeAssistant_B10.macro` instead
+* Configure the local variables as described in Step 2.2:
+  * **`ha_url`** (Secure): Your Home Assistant URL
+  * **`ha_token`** (Secure): Your Long-Lived Access Token
+  * **`ha_sensor_name`**: Set to `leapmotor_b10_1`
+* Add the contents of `sensor_b10.yaml` to your template sensor configuration
+* The main sensor will be `sensor.leapmotor_b10_1`
+* The charge status sensor will be `sensor.leapmotor_b10_charge_status`
+
 ## Prerequisites
 
 ### Required Software

--- a/sensor_b10.yaml
+++ b/sensor_b10.yaml
@@ -1,0 +1,64 @@
+template:
+  - sensor:
+      - name: "Leapmotor B10 Battery"
+        unique_id: leapmotor_b10_1_battery
+        state: "{{ state_attr('sensor.leapmotor_b10_1', 'battery_percent') }}"
+        unit_of_measurement: "%"
+        device_class: battery
+  
+      - name: "Leapmotor B10 Range"
+        unique_id: leapmotor_b10_1_range
+        state: "{{ state_attr('sensor.leapmotor_b10_1', 'remaining_range') }}"
+        unit_of_measurement: "km"
+        icon: mdi:map-marker-distance
+  
+      - name: "Leapmotor B10 Car Temperature"
+        unique_id: leapmotor_b10_1_car_temp
+        state: "{{ state_attr('sensor.leapmotor_b10_1', 'car_temp') }}"
+        unit_of_measurement: "°C"
+        device_class: temperature
+  
+      - name: "Leapmotor B10 Air Temperature"
+        unique_id: leapmotor_b10_1_air_temp
+        state: "{{ state_attr('sensor.leapmotor_b10_1', 'air_temp') }}"
+        unit_of_measurement: "°C"
+        device_class: temperature
+  
+      - name: "Leapmotor B10 Lock State"
+        unique_id: leapmotor_b10_1_lock_state
+        state: "{{ state_attr('sensor.leapmotor_b10_1', 'lock_state') }}"
+        icon: mdi:car-door-lock
+  
+      - name: "Leapmotor B10 Charge Status"
+        unique_id: leapmotor_b10_1_charge_status
+        state: "{{ states('sensor.leapmotor_b10_charge_status') }}"
+        icon: mdi:ev-plug-type2
+  
+      - name: "Leapmotor B10 Charge Power"
+        unique_id: leapmotor_b10_1_charge_power
+        state: "{{ state_attr('sensor.leapmotor_b10_1', 'charge_power_kw') }}"
+        unit_of_measurement: "kW"
+        device_class: power
+  
+      - name: "Leapmotor B10 Charge Current"
+        unique_id: leapmotor_b10_1_charge_current
+        state: "{{ state_attr('sensor.leapmotor_b10_1', 'charge_current_a') }}"
+        unit_of_measurement: "A"
+        device_class: current
+  
+      - name: "Leapmotor B10 Charge Limit"
+        unique_id: leapmotor_b10_1_charge_limit
+        state: "{{ state_attr('sensor.leapmotor_b10_1', 'charge_limit_percent') }}"
+        unit_of_measurement: "%"
+        icon: mdi:battery-charging-high
+  
+      - name: "Leapmotor B10 Charge Remaining"
+        unique_id: leapmotor_b10_1_charge_remaining
+        state: "{{ state_attr('sensor.leapmotor_b10_1', 'charge_remaining') }}"
+        icon: mdi:timer-outline
+    
+      - name: "Leapmotor B10 Odometer"
+        unique_id: leapmotor_b10_1_odometer
+        state: "{{ state_attr('sensor.leapmotor_b10_1', 'odometer') }}"
+        unit_of_measurement: "km"
+        icon: mdi:counter

--- a/sensor_b10.yaml
+++ b/sensor_b10.yaml
@@ -1,64 +1,85 @@
-template:
-  - sensor:
-      - name: "Leapmotor B10 Battery"
-        unique_id: leapmotor_b10_1_battery
-        state: "{{ state_attr('sensor.leapmotor_b10_1', 'battery_percent') }}"
-        unit_of_measurement: "%"
-        device_class: battery
+- sensor:
+    - name: "Leapmotor B10 Battery"
+      unique_id: leapmotor_b10_1_battery
+      state: "{{ state_attr('sensor.leapmotor_b10_1', 'battery_percent') }}"
+      unit_of_measurement: "%"
+      device_class: battery
+
+    - name: "Leapmotor B10 Range"
+      unique_id: leapmotor_b10_1_range
+      state: "{{ state_attr('sensor.leapmotor_b10_1', 'remaining_range') }}"
+      unit_of_measurement: "km"
+      icon: mdi:map-marker-distance
+
+    - name: "Leapmotor B10 Car Temperature"
+      unique_id: leapmotor_b10_1_car_temp
+      state: "{{ state_attr('sensor.leapmotor_b10_1', 'car_temp') }}"
+      unit_of_measurement: "°C"
+      device_class: temperature
+
+    - name: "Leapmotor B10 Air Temperature"
+      unique_id: leapmotor_b10_1_air_temp
+      state: "{{ state_attr('sensor.leapmotor_b10_1', 'air_temp') }}"
+      unit_of_measurement: "°C"
+      device_class: temperature
+
+    - name: "Leapmotor B10 Lock State"
+      unique_id: leapmotor_b10_1_lock_state
+      state: "{{ state_attr('sensor.leapmotor_b10_1', 'lock_state') }}"
+      icon: mdi:car-door-lock
+
+    - name: "Leapmotor B10 Charge Status"
+      unique_id: leapmotor_b10_1_charge_status
+      state: "{{ states('sensor.leapmotor_b10_charge_status') }}"
+      icon: mdi:ev-plug-type2
+
+    - name: "Leapmotor B10 Charge Power"
+      unique_id: leapmotor_b10_1_charge_power
+      state: "{{ state_attr('sensor.leapmotor_b10_1', 'charge_power_kw') }}"
+      unit_of_measurement: "kW"
+      device_class: power
+
+    - name: "Leapmotor B10 Charge Current"
+      unique_id: leapmotor_b10_1_charge_current
+      state: "{{ state_attr('sensor.leapmotor_b10_1', 'charge_current_a') }}"
+      unit_of_measurement: "A"
+      device_class: current
+
+    - name: "Leapmotor B10 Charge Limit"
+      unique_id: leapmotor_b10_1_charge_limit
+      state: "{{ state_attr('sensor.leapmotor_b10_1', 'charge_limit_percent') }}"
+      unit_of_measurement: "%"
+      icon: mdi:battery-charging-high
   
-      - name: "Leapmotor B10 Range"
-        unique_id: leapmotor_b10_1_range
-        state: "{{ state_attr('sensor.leapmotor_b10_1', 'remaining_range') }}"
-        unit_of_measurement: "km"
-        icon: mdi:map-marker-distance
-  
-      - name: "Leapmotor B10 Car Temperature"
-        unique_id: leapmotor_b10_1_car_temp
-        state: "{{ state_attr('sensor.leapmotor_b10_1', 'car_temp') }}"
-        unit_of_measurement: "°C"
-        device_class: temperature
-  
-      - name: "Leapmotor B10 Air Temperature"
-        unique_id: leapmotor_b10_1_air_temp
-        state: "{{ state_attr('sensor.leapmotor_b10_1', 'air_temp') }}"
-        unit_of_measurement: "°C"
-        device_class: temperature
-  
-      - name: "Leapmotor B10 Lock State"
-        unique_id: leapmotor_b10_1_lock_state
-        state: "{{ state_attr('sensor.leapmotor_b10_1', 'lock_state') }}"
-        icon: mdi:car-door-lock
-  
-      - name: "Leapmotor B10 Charge Status"
-        unique_id: leapmotor_b10_1_charge_status
-        state: "{{ states('sensor.leapmotor_b10_charge_status') }}"
-        icon: mdi:ev-plug-type2
-  
-      - name: "Leapmotor B10 Charge Power"
-        unique_id: leapmotor_b10_1_charge_power
-        state: "{{ state_attr('sensor.leapmotor_b10_1', 'charge_power_kw') }}"
-        unit_of_measurement: "kW"
-        device_class: power
-  
-      - name: "Leapmotor B10 Charge Current"
-        unique_id: leapmotor_b10_1_charge_current
-        state: "{{ state_attr('sensor.leapmotor_b10_1', 'charge_current_a') }}"
-        unit_of_measurement: "A"
-        device_class: current
-  
-      - name: "Leapmotor B10 Charge Limit"
-        unique_id: leapmotor_b10_1_charge_limit
-        state: "{{ state_attr('sensor.leapmotor_b10_1', 'charge_limit_percent') }}"
-        unit_of_measurement: "%"
-        icon: mdi:battery-charging-high
-  
-      - name: "Leapmotor B10 Charge Remaining"
-        unique_id: leapmotor_b10_1_charge_remaining
-        state: "{{ state_attr('sensor.leapmotor_b10_1', 'charge_remaining') }}"
-        icon: mdi:timer-outline
-    
-      - name: "Leapmotor B10 Odometer"
-        unique_id: leapmotor_b10_1_odometer
-        state: "{{ state_attr('sensor.leapmotor_b10_1', 'odometer') }}"
-        unit_of_measurement: "km"
-        icon: mdi:counter
+    - name: "Leapmotor B10 Odometer"
+      unique_id: leapmotor_b10_1_odometer
+      state: "{{ state_attr('sensor.leapmotor_b10_1', 'odometer') }}"
+      unit_of_measurement: "km"
+      icon: mdi:counter
+
+    - name: "Leapmotor B10 Charge Remaining"
+      unique_id: leapmotor_b10_1_charge_remaining
+      state: >
+        {% set s = state_attr('sensor.leapmotor_b10_1', 'charge_remaining') %}
+        {% if s and 'h' in s %}
+          {% set h = s | regex_findall('(\d+)h') | first | int(0) %}
+          {% set m = s | regex_findall('(\d+)min') | first | int(0) %}
+          {{ h * 60 + m }}
+        {% elif s and 'min' in s %}
+          {{ s | regex_findall('(\d+)min') | first | int(0) }}
+        {% else %}
+          0
+        {% endif %}
+      unit_of_measurement: "min"
+      icon: mdi:timer-outline
+
+    - name: "Leapmotor B10 Charge Complete At"
+      unique_id: leapmotor_b10_1_charge_complete_at
+      state: >
+        {% set mins = states('sensor.leapmotor_b10_charge_remaining') | int(0) %}
+        {% if mins > 0 %}
+          {{ (now() + timedelta(minutes=mins)).isoformat() }}
+        {% else %}
+          unknown
+        {% endif %}
+      icon: mdi:clock-end


### PR DESCRIPTION
Adds B10 support with extended macro (odometer, charge limit/current/power/remaining, A/B/C charge status logic) and corresponding sensor configuration.
Plz add in readme, that the Language in the Leapmotor App must be English for flawless working!
Ty
Toxo